### PR TITLE
重构SDK代码

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // 使用 IntelliSense 了解相关属性。 
+    // 悬停以查看现有属性的描述。
+    // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "remotePath": "",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${fileDirname}",
+            "env": {},
+            "args": [],
+            "showLog": true
+        }
+    ]
+}

--- a/yunpian/cache.go
+++ b/yunpian/cache.go
@@ -1,0 +1,260 @@
+package yunpian
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var invalidPath = errors.New("schema: invalid path")
+
+// newCache returns a new cache.
+func newCache() *cache {
+	c := cache{
+		m:       make(map[reflect.Type]*structInfo),
+		regconv: make(map[reflect.Type]Converter),
+		tag:     "schema",
+	}
+	return &c
+}
+
+// cache caches meta-data about a struct.
+type cache struct {
+	l       sync.RWMutex
+	m       map[reflect.Type]*structInfo
+	regconv map[reflect.Type]Converter
+	tag     string
+}
+
+// registerConverter registers a converter function for a custom type.
+func (c *cache) registerConverter(value interface{}, converterFunc Converter) {
+	c.regconv[reflect.TypeOf(value)] = converterFunc
+}
+
+// parsePath parses a path in dotted notation verifying that it is a valid
+// path to a struct field.
+//
+// It returns "path parts" which contain indices to fields to be used by
+// reflect.Value.FieldByString(). Multiple parts are required for slices of
+// structs.
+func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
+	var struc *structInfo
+	var field *fieldInfo
+	var index64 int64
+	var err error
+	parts := make([]pathPart, 0)
+	path := make([]string, 0)
+	keys := strings.Split(p, ".")
+	for i := 0; i < len(keys); i++ {
+		if t.Kind() != reflect.Struct {
+			return nil, invalidPath
+		}
+		if struc = c.get(t); struc == nil {
+			return nil, invalidPath
+		}
+		if field = struc.get(keys[i]); field == nil {
+			return nil, invalidPath
+		}
+		// Valid field. Append index.
+		path = append(path, field.name)
+		if field.ss {
+			// Parse a special case: slices of structs.
+			// i+1 must be the slice index.
+			//
+			// Now that struct can implements TextUnmarshaler interface,
+			// we don't need to force the struct's fields to appear in the path.
+			// So checking i+2 is not necessary anymore.
+			i++
+			if i+1 > len(keys) {
+				return nil, invalidPath
+			}
+			if index64, err = strconv.ParseInt(keys[i], 10, 0); err != nil {
+				return nil, invalidPath
+			}
+			parts = append(parts, pathPart{
+				path:  path,
+				field: field,
+				index: int(index64),
+			})
+			path = make([]string, 0)
+
+			// Get the next struct type, dropping ptrs.
+			if field.typ.Kind() == reflect.Ptr {
+				t = field.typ.Elem()
+			} else {
+				t = field.typ
+			}
+			if t.Kind() == reflect.Slice {
+				t = t.Elem()
+				if t.Kind() == reflect.Ptr {
+					t = t.Elem()
+				}
+			}
+		} else if field.typ.Kind() == reflect.Ptr {
+			t = field.typ.Elem()
+		} else {
+			t = field.typ
+		}
+	}
+	// Add the remaining.
+	parts = append(parts, pathPart{
+		path:  path,
+		field: field,
+		index: -1,
+	})
+	return parts, nil
+}
+
+// get returns a cached structInfo, creating it if necessary.
+func (c *cache) get(t reflect.Type) *structInfo {
+	c.l.RLock()
+	info := c.m[t]
+	c.l.RUnlock()
+	if info == nil {
+		info = c.create(t, nil)
+		c.l.Lock()
+		c.m[t] = info
+		c.l.Unlock()
+	}
+	return info
+}
+
+// create creates a structInfo with meta-data about a struct.
+func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
+	if info == nil {
+		info = &structInfo{fields: []*fieldInfo{}}
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous {
+			ft := field.Type
+			if ft.Kind() == reflect.Ptr {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct {
+				bef := len(info.fields)
+				c.create(ft, info)
+				for _, fi := range info.fields[bef:len(info.fields)] {
+					// exclude required check because duplicated to embedded field
+					fi.required = false
+				}
+			}
+		}
+		c.createField(field, info)
+	}
+	return info
+}
+
+// createField creates a fieldInfo for the given field.
+func (c *cache) createField(field reflect.StructField, info *structInfo) {
+	alias, options := fieldAlias(field, c.tag)
+	if alias == "-" {
+		// Ignore this field.
+		return
+	}
+	// Check if the type is supported and don't cache it if not.
+	// First let's get the basic type.
+	isSlice, isStruct := false, false
+	ft := field.Type
+	if ft.Kind() == reflect.Ptr {
+		ft = ft.Elem()
+	}
+	if isSlice = ft.Kind() == reflect.Slice; isSlice {
+		ft = ft.Elem()
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+	}
+	if ft.Kind() == reflect.Array {
+		ft = ft.Elem()
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+	}
+	if isStruct = ft.Kind() == reflect.Struct; !isStruct {
+		if c.converter(ft) == nil && builtinConverters[ft.Kind()] == nil {
+			// Type is not supported.
+			return
+		}
+	}
+
+	info.fields = append(info.fields, &fieldInfo{
+		typ:      field.Type,
+		name:     field.Name,
+		ss:       isSlice && isStruct,
+		alias:    alias,
+		anon:     field.Anonymous,
+		required: options.Contains("required"),
+	})
+}
+
+// converter returns the converter for a type.
+func (c *cache) converter(t reflect.Type) Converter {
+	return c.regconv[t]
+}
+
+// ----------------------------------------------------------------------------
+
+type structInfo struct {
+	fields []*fieldInfo
+}
+
+func (i *structInfo) get(alias string) *fieldInfo {
+	for _, field := range i.fields {
+		if strings.EqualFold(field.alias, alias) {
+			return field
+		}
+	}
+	return nil
+}
+
+type fieldInfo struct {
+	typ      reflect.Type
+	name     string // field name in the struct.
+	ss       bool   // true if this is a slice of structs.
+	alias    string
+	anon     bool // is an embedded field
+	required bool // tag option
+}
+
+type pathPart struct {
+	field *fieldInfo
+	path  []string // path to the field: walks structs using field names.
+	index int      // struct index in slices of structs.
+}
+
+// ----------------------------------------------------------------------------
+
+// fieldAlias parses a field tag to get a field alias.
+func fieldAlias(field reflect.StructField, tagName string) (alias string, options tagOptions) {
+	if tag := field.Tag.Get(tagName); tag != "" {
+		alias, options = parseTag(tag)
+	}
+	if alias == "" {
+		alias = field.Name
+	}
+	return alias, options
+}
+
+// tagOptions is the string following a comma in a struct field's tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/yunpian/client.go
+++ b/yunpian/client.go
@@ -1,0 +1,123 @@
+package yunpian
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Client provides a client to the YunPian API
+type Client struct {
+	config Config
+}
+
+// NewClient returns a new client
+func NewClient(config *Config) *Client {
+	cfg := DefaultConfig()
+	if config != nil {
+		cfg.MergeIn(config)
+	}
+
+	return &Client{config: *cfg}
+}
+
+// request is used to help build up a request
+type request struct {
+	config *Config
+	method string
+	url    *url.URL
+	params url.Values
+	body   io.Reader
+	header http.Header
+	ctx    context.Context
+}
+
+func (c *Client) newRequest(method, path string) *request {
+	r := &request{
+		config: &c.config,
+		method: method,
+		params: make(map[string][]string),
+		header: make(http.Header),
+		ctx:    c.config.Context,
+	}
+
+	u := &url.URL{
+		Host: c.config.smsHost,
+		Path: path,
+	}
+
+	if *c.config.UseSSL {
+		u.Scheme = "https"
+	} else {
+		u.Scheme = "http"
+	}
+
+	r.url = u
+	return r
+}
+
+func (c *Client) doRequest(r *request) (*http.Response, error) {
+	req, err := r.toHTTP()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.config.HTTPClient.Do(req)
+}
+
+func (r *request) toHTTP() (*http.Request, error) {
+	r.url.RawQuery = r.params.Encode()
+
+	req, err := http.NewRequest(r.method, r.url.RequestURI(), r.body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL.Host = r.url.Host
+	req.URL.Scheme = r.url.Scheme
+	req.Host = r.url.Host
+	req.Header = r.header
+
+	req.Header.Set("Api-Lang", "go")
+	req.Header.Set("Connection", "Keep-Alive")
+
+	if r.ctx != nil {
+		return req.WithContext(r.ctx), nil
+	}
+
+	return req, nil
+}
+
+// encodeFormBody is used to Form encode a request body
+func (c *Client) encodeFormBody(obj interface{}) (io.Reader, error) {
+	encoder := NewEncoder()
+	form := url.Values{}
+	err := encoder.Encode(obj, form)
+	if err != nil {
+		return nil, err
+	}
+
+	form.Set("apikey", *c.config.APIKey)
+	return strings.NewReader(form.Encode()), nil
+}
+
+func (c *Client) handleResponse(resp *http.Response, out interface{}) error {
+	if resp.StatusCode >= http.StatusBadRequest {
+		var err ErrorResponse
+		if e := c.decodeJSONBody(resp, &err); e != nil {
+			return e
+		}
+		return err
+	}
+
+	return c.decodeJSONBody(resp, out)
+}
+
+// decodeJSONBody is used to JSON decode a body
+func (c *Client) decodeJSONBody(resp *http.Response, out interface{}) error {
+	dec := json.NewDecoder(resp.Body)
+	return dec.Decode(out)
+}

--- a/yunpian/client.go
+++ b/yunpian/client.go
@@ -35,7 +35,7 @@ type request struct {
 	ctx    context.Context
 }
 
-func (c *Client) newRequest(method, path string) *request {
+func (c *Client) newRequest(method, endpoint, path string) *request {
 	r := &request{
 		config: &c.config,
 		method: method,
@@ -45,7 +45,7 @@ func (c *Client) newRequest(method, path string) *request {
 	}
 
 	u := &url.URL{
-		Host: c.config.smsHost,
+		Host: endpoint,
 		Path: path,
 	}
 

--- a/yunpian/client_test.go
+++ b/yunpian/client_test.go
@@ -1,0 +1,4 @@
+package yunpian
+
+var TestConfig = DefaultDevConfig().WithAPIKey("")
+var TestClient = NewClient(TestConfig)

--- a/yunpian/client_test.go
+++ b/yunpian/client_test.go
@@ -1,4 +1,4 @@
 package yunpian
 
-var TestConfig = DefaultConfig().WithAPIKey("6356af7171d65acc5abd8ee19b5edc25")
+var TestConfig = DefaultDevConfig().WithAPIKey("")
 var TestClient = NewClient(TestConfig)

--- a/yunpian/client_test.go
+++ b/yunpian/client_test.go
@@ -1,4 +1,4 @@
 package yunpian
 
-var TestConfig = DefaultDevConfig().WithAPIKey("")
+var TestConfig = DefaultConfig().WithAPIKey("6356af7171d65acc5abd8ee19b5edc25")
 var TestClient = NewClient(TestConfig)

--- a/yunpian/config.go
+++ b/yunpian/config.go
@@ -1,0 +1,110 @@
+package yunpian
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Config - SDK 配置项，可以将允许用户配置的参数放入这里
+type Config struct {
+	UseSSL     *bool
+	HTTPClient *http.Client
+	APIKey     *string
+	Context    context.Context
+
+	userHost  string
+	signHost  string
+	tplHost   string
+	smsHost   string
+	voiceHost string
+	flowHost  string
+}
+
+func (c *Config) WithAPIKey(key string) *Config {
+	c.APIKey = &key
+	return c
+}
+
+func (c *Config) WithUseSSL(use bool) *Config {
+	c.UseSSL = &use
+	return c
+}
+
+func (c *Config) WithHTTPClient(client *http.Client) *Config {
+	c.HTTPClient = client
+	return c
+}
+
+func (c *Config) WithContext(ctx context.Context) *Config {
+	c.Context = ctx
+	return c
+}
+
+// MergeIn merges the passed in configs into the existing config object.
+func (c *Config) MergeIn(cfgs ...*Config) {
+	for _, other := range cfgs {
+		mergeInConfig(c, other)
+	}
+}
+
+func mergeInConfig(dst *Config, other *Config) {
+	if other == nil {
+		return
+	}
+
+	if other.APIKey != nil {
+		dst.APIKey = other.APIKey
+	}
+	if other.UseSSL != nil {
+		dst.UseSSL = other.UseSSL
+	}
+	if other.HTTPClient != nil {
+		dst.HTTPClient = other.HTTPClient
+	}
+	if other.Context != nil {
+		dst.Context = other.Context
+	}
+}
+
+// DefaultDevConfig returns a default dev client config pointer
+func DefaultDevConfig() *Config {
+	cfg := &Config{
+		userHost:  "test-api.yunpian.com",
+		signHost:  "test-api.yunpian.com",
+		tplHost:   "test-api.yunpian.com",
+		smsHost:   "test-api.yunpian.com",
+		voiceHost: "test-api.yunpian.com",
+		flowHost:  "test-api.yunpian.com",
+	}
+	return cfg.WithUseSSL(true).WithHTTPClient(defaultHTTPClient())
+}
+
+// DefaultConfig returns a default client config pointer
+func DefaultConfig() *Config {
+	cfg := &Config{
+		userHost:  "sms.yunpian.com",
+		signHost:  "sms.yunpian.com",
+		tplHost:   "sms.yunpian.com",
+		smsHost:   "sms.yunpian.com",
+		voiceHost: "voice.yunpian.com",
+		flowHost:  "flow.yunpian.com",
+	}
+	return cfg.WithUseSSL(true).WithHTTPClient(defaultHTTPClient())
+}
+
+func defaultHTTPClient() *http.Client {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:        100,
+		IdleConnTimeout:     30 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+
+	return &http.Client{Transport: transport}
+}

--- a/yunpian/converter.go
+++ b/yunpian/converter.go
@@ -1,0 +1,141 @@
+package yunpian
+
+import (
+	"reflect"
+	"strconv"
+)
+
+type Converter func(string) reflect.Value
+
+var (
+	invalidValue = reflect.Value{}
+	boolType     = reflect.Bool
+	float32Type  = reflect.Float32
+	float64Type  = reflect.Float64
+	intType      = reflect.Int
+	int8Type     = reflect.Int8
+	int16Type    = reflect.Int16
+	int32Type    = reflect.Int32
+	int64Type    = reflect.Int64
+	stringType   = reflect.String
+	uintType     = reflect.Uint
+	uint8Type    = reflect.Uint8
+	uint16Type   = reflect.Uint16
+	uint32Type   = reflect.Uint32
+	uint64Type   = reflect.Uint64
+)
+
+// Default converters for basic types.
+var builtinConverters = map[reflect.Kind]Converter{
+	boolType:    convertBool,
+	float32Type: convertFloat32,
+	float64Type: convertFloat64,
+	intType:     convertInt,
+	int8Type:    convertInt8,
+	int16Type:   convertInt16,
+	int32Type:   convertInt32,
+	int64Type:   convertInt64,
+	stringType:  convertString,
+	uintType:    convertUint,
+	uint8Type:   convertUint8,
+	uint16Type:  convertUint16,
+	uint32Type:  convertUint32,
+	uint64Type:  convertUint64,
+}
+
+func convertBool(value string) reflect.Value {
+	if value == "on" {
+		return reflect.ValueOf(true)
+	} else if v, err := strconv.ParseBool(value); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}
+
+func convertFloat32(value string) reflect.Value {
+	if v, err := strconv.ParseFloat(value, 32); err == nil {
+		return reflect.ValueOf(float32(v))
+	}
+	return invalidValue
+}
+
+func convertFloat64(value string) reflect.Value {
+	if v, err := strconv.ParseFloat(value, 64); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}
+
+func convertInt(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 0); err == nil {
+		return reflect.ValueOf(int(v))
+	}
+	return invalidValue
+}
+
+func convertInt8(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 8); err == nil {
+		return reflect.ValueOf(int8(v))
+	}
+	return invalidValue
+}
+
+func convertInt16(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 16); err == nil {
+		return reflect.ValueOf(int16(v))
+	}
+	return invalidValue
+}
+
+func convertInt32(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 32); err == nil {
+		return reflect.ValueOf(int32(v))
+	}
+	return invalidValue
+}
+
+func convertInt64(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}
+
+func convertString(value string) reflect.Value {
+	return reflect.ValueOf(value)
+}
+
+func convertUint(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 0); err == nil {
+		return reflect.ValueOf(uint(v))
+	}
+	return invalidValue
+}
+
+func convertUint8(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 8); err == nil {
+		return reflect.ValueOf(uint8(v))
+	}
+	return invalidValue
+}
+
+func convertUint16(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 16); err == nil {
+		return reflect.ValueOf(uint16(v))
+	}
+	return invalidValue
+}
+
+func convertUint32(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 32); err == nil {
+		return reflect.ValueOf(uint32(v))
+	}
+	return invalidValue
+}
+
+func convertUint64(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}

--- a/yunpian/decoder.go
+++ b/yunpian/decoder.go
@@ -1,0 +1,414 @@
+package yunpian
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// NewDecoder returns a new Decoder.
+func NewDecoder() *Decoder {
+	return &Decoder{cache: newCache()}
+}
+
+// Decoder decodes values from a map[string][]string to a struct.
+type Decoder struct {
+	cache             *cache
+	zeroEmpty         bool
+	ignoreUnknownKeys bool
+}
+
+// SetAliasTag changes the tag used to locate custom field aliases.
+// The default tag is "schema".
+func (d *Decoder) SetAliasTag(tag string) {
+	d.cache.tag = tag
+}
+
+// ZeroEmpty controls the behaviour when the decoder encounters empty values
+// in a map.
+// If z is true and a key in the map has the empty string as a value
+// then the corresponding struct field is set to the zero value.
+// If z is false then empty strings are ignored.
+//
+// The default value is false, that is empty values do not change
+// the value of the struct field.
+func (d *Decoder) ZeroEmpty(z bool) {
+	d.zeroEmpty = z
+}
+
+// IgnoreUnknownKeys controls the behaviour when the decoder encounters unknown
+// keys in the map.
+// If i is true and an unknown field is encountered, it is ignored. This is
+// similar to how unknown keys are handled by encoding/json.
+// If i is false then Decode will return an error. Note that any valid keys
+// will still be decoded in to the target struct.
+//
+// To preserve backwards compatibility, the default value is false.
+func (d *Decoder) IgnoreUnknownKeys(i bool) {
+	d.ignoreUnknownKeys = i
+}
+
+// RegisterConverter registers a converter function for a custom type.
+func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) {
+	d.cache.registerConverter(value, converterFunc)
+}
+
+// Decode decodes a map[string][]string to a struct.
+//
+// The first parameter must be a pointer to a struct.
+//
+// The second parameter is a map, typically url.Values from an HTTP request.
+// Keys are "paths" in dotted notation to the struct fields and nested structs.
+//
+// See the package documentation for a full explanation of the mechanics.
+func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return errors.New("schema: interface must be a pointer to struct")
+	}
+	v = v.Elem()
+	t := v.Type()
+	errors := MultiError{}
+	for path, values := range src {
+		if parts, err := d.cache.parsePath(path, t); err == nil {
+			if err = d.decode(v, path, parts, values); err != nil {
+				errors[path] = err
+			}
+		} else if !d.ignoreUnknownKeys {
+			errors[path] = fmt.Errorf("schema: invalid path %q", path)
+		}
+	}
+	if len(errors) > 0 {
+		return errors
+	}
+	return d.checkRequired(t, src, "")
+}
+
+// checkRequired checks whether required fields are empty
+//
+// check type t recursively if t has struct fields, and prefix is same as parsePath: in dotted notation
+//
+// src is the source map for decoding, we use it here to see if those required fields are included in src
+func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix string) error {
+	struc := d.cache.get(t)
+	if struc == nil {
+		// unexpect, cache.get never return nil
+		return errors.New("cache fail")
+	}
+
+	for _, f := range struc.fields {
+		if f.typ.Kind() == reflect.Struct {
+			err := d.checkRequired(f.typ, src, prefix+f.alias+".")
+			if err != nil {
+				if !f.anon {
+					return err
+				}
+				// check embedded parent field.
+				err2 := d.checkRequired(f.typ, src, prefix)
+				if err2 != nil {
+					return err
+				}
+			}
+		}
+		if f.required {
+			key := f.alias
+			if prefix != "" {
+				key = prefix + key
+			}
+			if isEmpty(f.typ, src[key]) {
+				return fmt.Errorf("%v is empty", key)
+			}
+		}
+	}
+	return nil
+}
+
+// isEmpty returns true if value is empty for specific type
+func isEmpty(t reflect.Type, value []string) bool {
+	if len(value) == 0 {
+		return true
+	}
+	switch t.Kind() {
+	case boolType, float32Type, float64Type, intType, int8Type, int32Type, int64Type, stringType, uint8Type, uint16Type, uint32Type, uint64Type:
+		return len(value[0]) == 0
+	}
+	return false
+}
+
+// decode fills a struct field using a parsed path.
+func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values []string) error {
+
+	// Get the field walking the struct fields by index.
+	for _, name := range parts[0].path {
+		if v.Type().Kind() == reflect.Ptr {
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.FieldByName(name)
+	}
+	// Don't even bother for unexported fields.
+	if !v.CanSet() {
+		return nil
+	}
+
+	// Dereference if needed.
+	t := v.Type()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		if v.IsNil() {
+			v.Set(reflect.New(t))
+		}
+		v = v.Elem()
+	}
+
+	// Slice of structs. Let's go recursive.
+	if len(parts) > 1 {
+		idx := parts[0].index
+		if v.IsNil() || v.Len() < idx+1 {
+			value := reflect.MakeSlice(t, idx+1, idx+1)
+			if v.Len() < idx+1 {
+				// Resize it.
+				reflect.Copy(value, v)
+			}
+			v.Set(value)
+		}
+		return d.decode(v.Index(idx), path, parts[1:], values)
+	}
+
+	// Get the converter early in case there is one for a slice type.
+	conv := d.cache.converter(t)
+	if conv == nil && t.Kind() == reflect.Slice {
+		var items []reflect.Value
+		elemT := t.Elem()
+		isPtrElem := elemT.Kind() == reflect.Ptr
+		if isPtrElem {
+			elemT = elemT.Elem()
+		}
+
+		// Try to get a converter for the element type.
+		conv := d.cache.converter(elemT)
+		if conv == nil {
+			conv = builtinConverters[elemT.Kind()]
+			if conv == nil {
+				// As we are not dealing with slice of structs here, we don't need to check if the type
+				// implements TextUnmarshaler interface
+				return fmt.Errorf("schema: converter not found for %v", elemT)
+			}
+		}
+
+		for key, value := range values {
+			if value == "" {
+				if d.zeroEmpty {
+					items = append(items, reflect.Zero(elemT))
+				}
+			} else if m := isTextUnmarshaler(v); m.IsValid {
+				u := reflect.New(elemT)
+				if m.IsPtr {
+					u = reflect.New(reflect.PtrTo(elemT).Elem())
+				}
+				if err := u.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(value)); err != nil {
+					return ConversionError{
+						Key:   path,
+						Type:  t,
+						Index: key,
+						Err:   err,
+					}
+				}
+				if m.IsPtr {
+					items = append(items, u.Elem().Addr())
+				} else if u.Kind() == reflect.Ptr {
+					items = append(items, u.Elem())
+				} else {
+					items = append(items, u)
+				}
+			} else if item := conv(value); item.IsValid() {
+				if isPtrElem {
+					ptr := reflect.New(elemT)
+					ptr.Elem().Set(item)
+					item = ptr
+				}
+				if item.Type() != elemT && !isPtrElem {
+					item = item.Convert(elemT)
+				}
+				items = append(items, item)
+			} else {
+				if strings.Contains(value, ",") {
+					values := strings.Split(value, ",")
+					for _, value := range values {
+						if value == "" {
+							if d.zeroEmpty {
+								items = append(items, reflect.Zero(elemT))
+							}
+						} else if item := conv(value); item.IsValid() {
+							if isPtrElem {
+								ptr := reflect.New(elemT)
+								ptr.Elem().Set(item)
+								item = ptr
+							}
+							if item.Type() != elemT && !isPtrElem {
+								item = item.Convert(elemT)
+							}
+							items = append(items, item)
+						} else {
+							return ConversionError{
+								Key:   path,
+								Type:  elemT,
+								Index: key,
+							}
+						}
+					}
+				} else {
+					return ConversionError{
+						Key:   path,
+						Type:  elemT,
+						Index: key,
+					}
+				}
+			}
+		}
+		value := reflect.Append(reflect.MakeSlice(t, 0, 0), items...)
+		v.Set(value)
+	} else {
+		val := ""
+		// Use the last value provided if any values were provided
+		if len(values) > 0 {
+			val = values[len(values)-1]
+		}
+
+		if val == "" {
+			if d.zeroEmpty {
+				v.Set(reflect.Zero(t))
+			}
+		} else if conv != nil {
+			if value := conv(val); value.IsValid() {
+				v.Set(value.Convert(t))
+			} else {
+				return ConversionError{
+					Key:   path,
+					Type:  t,
+					Index: -1,
+				}
+			}
+		} else if m := isTextUnmarshaler(v); m.IsValid {
+			// If the value implements the encoding.TextUnmarshaler interface
+			// apply UnmarshalText as the converter
+			if err := m.Unmarshaler.UnmarshalText([]byte(val)); err != nil {
+				return ConversionError{
+					Key:   path,
+					Type:  t,
+					Index: -1,
+					Err:   err,
+				}
+			}
+		} else if conv := builtinConverters[t.Kind()]; conv != nil {
+			if value := conv(val); value.IsValid() {
+				v.Set(value.Convert(t))
+			} else {
+				return ConversionError{
+					Key:   path,
+					Type:  t,
+					Index: -1,
+				}
+			}
+		} else {
+			return fmt.Errorf("schema: converter not found for %v", t)
+		}
+	}
+	return nil
+}
+
+func isTextUnmarshaler(v reflect.Value) unmarshaler {
+
+	// Create a new unmarshaller instance
+	m := unmarshaler{}
+
+	// As the UnmarshalText function should be applied
+	// to the pointer of the type, we convert the value to pointer.
+	if v.CanAddr() {
+		v = v.Addr()
+	}
+	if m.Unmarshaler, m.IsValid = v.Interface().(encoding.TextUnmarshaler); m.IsValid {
+		return m
+	}
+
+	// if v is []T or *[]T create new T
+	t := v.Type()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Slice {
+		// if t is a pointer slice, check if it implements encoding.TextUnmarshaler
+		if t = t.Elem(); t.Kind() == reflect.Ptr {
+			t = reflect.PtrTo(t.Elem())
+			v = reflect.Zero(t)
+			m.IsPtr = true
+			m.Unmarshaler, m.IsValid = v.Interface().(encoding.TextUnmarshaler)
+			return m
+		}
+	}
+
+	v = reflect.New(t)
+	m.Unmarshaler, m.IsValid = v.Interface().(encoding.TextUnmarshaler)
+	return m
+}
+
+// TextUnmarshaler helpers ----------------------------------------------------
+// unmarshaller contains information about a TextUnmarshaler type
+type unmarshaler struct {
+	Unmarshaler encoding.TextUnmarshaler
+	IsPtr       bool
+	IsValid     bool
+}
+
+// Errors ---------------------------------------------------------------------
+
+// ConversionError stores information about a failed conversion.
+type ConversionError struct {
+	Key   string       // key from the source map.
+	Type  reflect.Type // expected type of elem
+	Index int          // index for multi-value fields; -1 for single-value fields.
+	Err   error        // low-level error (when it exists)
+}
+
+func (e ConversionError) Error() string {
+	var output string
+
+	if e.Index < 0 {
+		output = fmt.Sprintf("schema: error converting value for %q", e.Key)
+	} else {
+		output = fmt.Sprintf("schema: error converting value for index %d of %q",
+			e.Index, e.Key)
+	}
+
+	if e.Err != nil {
+		output = fmt.Sprintf("%s. Details: %s", output, e.Err)
+	}
+
+	return output
+}
+
+// MultiError stores multiple decoding errors.
+//
+// Borrowed from the App Engine SDK.
+type MultiError map[string]error
+
+func (e MultiError) Error() string {
+	s := ""
+	for _, err := range e {
+		s = err.Error()
+		break
+	}
+	switch len(e) {
+	case 0:
+		return "(0 errors)"
+	case 1:
+		return s
+	case 2:
+		return s + " (and 1 other error)"
+	}
+	return fmt.Sprintf("%s (and %d other errors)", s, len(e)-1)
+}

--- a/yunpian/decoder_test.go
+++ b/yunpian/decoder_test.go
@@ -1,0 +1,1655 @@
+package yunpian
+
+import (
+	"encoding/hex"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type IntAlias int
+
+type rudeBool bool
+
+func (id *rudeBool) UnmarshalText(text []byte) error {
+	value := string(text)
+	switch {
+	case strings.EqualFold("Yup", value):
+		*id = true
+	case strings.EqualFold("Nope", value):
+		*id = false
+	default:
+		return errors.New("value must be yup or nope")
+	}
+	return nil
+}
+
+// All cases we want to cover, in a nutshell.
+type S1 struct {
+	F01 int         `schema:"f1"`
+	F02 *int        `schema:"f2"`
+	F03 []int       `schema:"f3"`
+	F04 []*int      `schema:"f4"`
+	F05 *[]int      `schema:"f5"`
+	F06 *[]*int     `schema:"f6"`
+	F07 S2          `schema:"f7"`
+	F08 *S1         `schema:"f8"`
+	F09 int         `schema:"-"`
+	F10 []S1        `schema:"f10"`
+	F11 []*S1       `schema:"f11"`
+	F12 *[]S1       `schema:"f12"`
+	F13 *[]*S1      `schema:"f13"`
+	F14 int         `schema:"f14"`
+	F15 IntAlias    `schema:"f15"`
+	F16 []IntAlias  `schema:"f16"`
+	F17 S19         `schema:"f17"`
+	F18 rudeBool    `schema:"f18"`
+	F19 *rudeBool   `schema:"f19"`
+	F20 []rudeBool  `schema:"f20"`
+	F21 []*rudeBool `schema:"f21"`
+}
+
+type S2 struct {
+	F01 *[]*int `schema:"f1"`
+}
+
+type S19 [2]byte
+
+func (id *S19) UnmarshalText(text []byte) error {
+	buf, err := hex.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	if len(buf) > len(*id) {
+		return errors.New("out of range")
+	}
+	for i := range buf {
+		(*id)[i] = buf[i]
+	}
+	return nil
+}
+
+func TestAll(t *testing.T) {
+	v := map[string][]string{
+		"f1":             {"1"},
+		"f2":             {"2"},
+		"f3":             {"31", "32"},
+		"f4":             {"41", "42"},
+		"f5":             {"51", "52"},
+		"f6":             {"61", "62"},
+		"f7.f1":          {"71", "72"},
+		"f8.f8.f7.f1":    {"81", "82"},
+		"f9":             {"9"},
+		"f10.0.f10.0.f6": {"101", "102"},
+		"f10.0.f10.1.f6": {"103", "104"},
+		"f11.0.f11.0.f6": {"111", "112"},
+		"f11.0.f11.1.f6": {"113", "114"},
+		"f12.0.f12.0.f6": {"121", "122"},
+		"f12.0.f12.1.f6": {"123", "124"},
+		"f13.0.f13.0.f6": {"131", "132"},
+		"f13.0.f13.1.f6": {"133", "134"},
+		"f14":            {},
+		"f15":            {"151"},
+		"f16":            {"161", "162"},
+		"f17":            {"1a2b"},
+		"f18":            {"yup"},
+		"f19":            {"nope"},
+		"f20":            {"nope", "yup"},
+		"f21":            {"yup", "nope"},
+	}
+	f2 := 2
+	f41, f42 := 41, 42
+	f61, f62 := 61, 62
+	f71, f72 := 71, 72
+	f81, f82 := 81, 82
+	f101, f102, f103, f104 := 101, 102, 103, 104
+	f111, f112, f113, f114 := 111, 112, 113, 114
+	f121, f122, f123, f124 := 121, 122, 123, 124
+	f131, f132, f133, f134 := 131, 132, 133, 134
+	var f151 IntAlias = 151
+	var f161, f162 IntAlias = 161, 162
+	var f152, f153 rudeBool = true, false
+	e := S1{
+		F01: 1,
+		F02: &f2,
+		F03: []int{31, 32},
+		F04: []*int{&f41, &f42},
+		F05: &[]int{51, 52},
+		F06: &[]*int{&f61, &f62},
+		F07: S2{
+			F01: &[]*int{&f71, &f72},
+		},
+		F08: &S1{
+			F08: &S1{
+				F07: S2{
+					F01: &[]*int{&f81, &f82},
+				},
+			},
+		},
+		F09: 0,
+		F10: []S1{
+			S1{
+				F10: []S1{
+					S1{F06: &[]*int{&f101, &f102}},
+					S1{F06: &[]*int{&f103, &f104}},
+				},
+			},
+		},
+		F11: []*S1{
+			&S1{
+				F11: []*S1{
+					&S1{F06: &[]*int{&f111, &f112}},
+					&S1{F06: &[]*int{&f113, &f114}},
+				},
+			},
+		},
+		F12: &[]S1{
+			S1{
+				F12: &[]S1{
+					S1{F06: &[]*int{&f121, &f122}},
+					S1{F06: &[]*int{&f123, &f124}},
+				},
+			},
+		},
+		F13: &[]*S1{
+			&S1{
+				F13: &[]*S1{
+					&S1{F06: &[]*int{&f131, &f132}},
+					&S1{F06: &[]*int{&f133, &f134}},
+				},
+			},
+		},
+		F14: 0,
+		F15: f151,
+		F16: []IntAlias{f161, f162},
+		F17: S19{0x1a, 0x2b},
+		F18: f152,
+		F19: &f153,
+		F20: []rudeBool{f153, f152},
+		F21: []*rudeBool{&f152, &f153},
+	}
+
+	s := &S1{}
+	_ = NewDecoder().Decode(s, v)
+
+	vals := func(values []*int) []int {
+		r := make([]int, len(values))
+		for k, v := range values {
+			r[k] = *v
+		}
+		return r
+	}
+
+	if s.F01 != e.F01 {
+		t.Errorf("f1: expected %v, got %v", e.F01, s.F01)
+	}
+	if s.F02 == nil {
+		t.Errorf("f2: expected %v, got nil", *e.F02)
+	} else if *s.F02 != *e.F02 {
+		t.Errorf("f2: expected %v, got %v", *e.F02, *s.F02)
+	}
+	if s.F03 == nil {
+		t.Errorf("f3: expected %v, got nil", e.F03)
+	} else if len(s.F03) != 2 || s.F03[0] != e.F03[0] || s.F03[1] != e.F03[1] {
+		t.Errorf("f3: expected %v, got %v", e.F03, s.F03)
+	}
+	if s.F04 == nil {
+		t.Errorf("f4: expected %v, got nil", e.F04)
+	} else {
+		if len(s.F04) != 2 || *(s.F04)[0] != *(e.F04)[0] || *(s.F04)[1] != *(e.F04)[1] {
+			t.Errorf("f4: expected %v, got %v", vals(e.F04), vals(s.F04))
+		}
+	}
+	if s.F05 == nil {
+		t.Errorf("f5: expected %v, got nil", e.F05)
+	} else {
+		sF05, eF05 := *s.F05, *e.F05
+		if len(sF05) != 2 || sF05[0] != eF05[0] || sF05[1] != eF05[1] {
+			t.Errorf("f5: expected %v, got %v", eF05, sF05)
+		}
+	}
+	if s.F06 == nil {
+		t.Errorf("f6: expected %v, got nil", vals(*e.F06))
+	} else {
+		sF06, eF06 := *s.F06, *e.F06
+		if len(sF06) != 2 || *(sF06)[0] != *(eF06)[0] || *(sF06)[1] != *(eF06)[1] {
+			t.Errorf("f6: expected %v, got %v", vals(eF06), vals(sF06))
+		}
+	}
+	if s.F07.F01 == nil {
+		t.Errorf("f7.f1: expected %v, got nil", vals(*e.F07.F01))
+	} else {
+		sF07, eF07 := *s.F07.F01, *e.F07.F01
+		if len(sF07) != 2 || *(sF07)[0] != *(eF07)[0] || *(sF07)[1] != *(eF07)[1] {
+			t.Errorf("f7.f1: expected %v, got %v", vals(eF07), vals(sF07))
+		}
+	}
+	if s.F08 == nil {
+		t.Errorf("f8: got nil")
+	} else if s.F08.F08 == nil {
+		t.Errorf("f8.f8: got nil")
+	} else if s.F08.F08.F07.F01 == nil {
+		t.Errorf("f8.f8.f7.f1: expected %v, got nil", vals(*e.F08.F08.F07.F01))
+	} else {
+		sF08, eF08 := *s.F08.F08.F07.F01, *e.F08.F08.F07.F01
+		if len(sF08) != 2 || *(sF08)[0] != *(eF08)[0] || *(sF08)[1] != *(eF08)[1] {
+			t.Errorf("f8.f8.f7.f1: expected %v, got %v", vals(eF08), vals(sF08))
+		}
+	}
+	if s.F09 != e.F09 {
+		t.Errorf("f9: expected %v, got %v", e.F09, s.F09)
+	}
+	if s.F10 == nil {
+		t.Errorf("f10: got nil")
+	} else if len(s.F10) != 1 {
+		t.Errorf("f10: expected 1 element, got %v", s.F10)
+	} else {
+		if len(s.F10[0].F10) != 2 {
+			t.Errorf("f10.0.f10: expected 1 element, got %v", s.F10[0].F10)
+		} else {
+			sF10, eF10 := *s.F10[0].F10[0].F06, *e.F10[0].F10[0].F06
+			if sF10 == nil {
+				t.Errorf("f10.0.f10.0.f6: expected %v, got nil", vals(eF10))
+			} else {
+				if len(sF10) != 2 || *(sF10)[0] != *(eF10)[0] || *(sF10)[1] != *(eF10)[1] {
+					t.Errorf("f10.0.f10.0.f6: expected %v, got %v", vals(eF10), vals(sF10))
+				}
+			}
+			sF10, eF10 = *s.F10[0].F10[1].F06, *e.F10[0].F10[1].F06
+			if sF10 == nil {
+				t.Errorf("f10.0.f10.0.f6: expected %v, got nil", vals(eF10))
+			} else {
+				if len(sF10) != 2 || *(sF10)[0] != *(eF10)[0] || *(sF10)[1] != *(eF10)[1] {
+					t.Errorf("f10.0.f10.0.f6: expected %v, got %v", vals(eF10), vals(sF10))
+				}
+			}
+		}
+	}
+	if s.F11 == nil {
+		t.Errorf("f11: got nil")
+	} else if len(s.F11) != 1 {
+		t.Errorf("f11: expected 1 element, got %v", s.F11)
+	} else {
+		if len(s.F11[0].F11) != 2 {
+			t.Errorf("f11.0.f11: expected 1 element, got %v", s.F11[0].F11)
+		} else {
+			sF11, eF11 := *s.F11[0].F11[0].F06, *e.F11[0].F11[0].F06
+			if sF11 == nil {
+				t.Errorf("f11.0.f11.0.f6: expected %v, got nil", vals(eF11))
+			} else {
+				if len(sF11) != 2 || *(sF11)[0] != *(eF11)[0] || *(sF11)[1] != *(eF11)[1] {
+					t.Errorf("f11.0.f11.0.f6: expected %v, got %v", vals(eF11), vals(sF11))
+				}
+			}
+			sF11, eF11 = *s.F11[0].F11[1].F06, *e.F11[0].F11[1].F06
+			if sF11 == nil {
+				t.Errorf("f11.0.f11.0.f6: expected %v, got nil", vals(eF11))
+			} else {
+				if len(sF11) != 2 || *(sF11)[0] != *(eF11)[0] || *(sF11)[1] != *(eF11)[1] {
+					t.Errorf("f11.0.f11.0.f6: expected %v, got %v", vals(eF11), vals(sF11))
+				}
+			}
+		}
+	}
+	if s.F12 == nil {
+		t.Errorf("f12: got nil")
+	} else if len(*s.F12) != 1 {
+		t.Errorf("f12: expected 1 element, got %v", *s.F12)
+	} else {
+		sF12, eF12 := *(s.F12), *(e.F12)
+		if len(*sF12[0].F12) != 2 {
+			t.Errorf("f12.0.f12: expected 1 element, got %v", *sF12[0].F12)
+		} else {
+			sF122, eF122 := *(*sF12[0].F12)[0].F06, *(*eF12[0].F12)[0].F06
+			if sF122 == nil {
+				t.Errorf("f12.0.f12.0.f6: expected %v, got nil", vals(eF122))
+			} else {
+				if len(sF122) != 2 || *(sF122)[0] != *(eF122)[0] || *(sF122)[1] != *(eF122)[1] {
+					t.Errorf("f12.0.f12.0.f6: expected %v, got %v", vals(eF122), vals(sF122))
+				}
+			}
+			sF122, eF122 = *(*sF12[0].F12)[1].F06, *(*eF12[0].F12)[1].F06
+			if sF122 == nil {
+				t.Errorf("f12.0.f12.0.f6: expected %v, got nil", vals(eF122))
+			} else {
+				if len(sF122) != 2 || *(sF122)[0] != *(eF122)[0] || *(sF122)[1] != *(eF122)[1] {
+					t.Errorf("f12.0.f12.0.f6: expected %v, got %v", vals(eF122), vals(sF122))
+				}
+			}
+		}
+	}
+	if s.F13 == nil {
+		t.Errorf("f13: got nil")
+	} else if len(*s.F13) != 1 {
+		t.Errorf("f13: expected 1 element, got %v", *s.F13)
+	} else {
+		sF13, eF13 := *(s.F13), *(e.F13)
+		if len(*sF13[0].F13) != 2 {
+			t.Errorf("f13.0.f13: expected 1 element, got %v", *sF13[0].F13)
+		} else {
+			sF132, eF132 := *(*sF13[0].F13)[0].F06, *(*eF13[0].F13)[0].F06
+			if sF132 == nil {
+				t.Errorf("f13.0.f13.0.f6: expected %v, got nil", vals(eF132))
+			} else {
+				if len(sF132) != 2 || *(sF132)[0] != *(eF132)[0] || *(sF132)[1] != *(eF132)[1] {
+					t.Errorf("f13.0.f13.0.f6: expected %v, got %v", vals(eF132), vals(sF132))
+				}
+			}
+			sF132, eF132 = *(*sF13[0].F13)[1].F06, *(*eF13[0].F13)[1].F06
+			if sF132 == nil {
+				t.Errorf("f13.0.f13.0.f6: expected %v, got nil", vals(eF132))
+			} else {
+				if len(sF132) != 2 || *(sF132)[0] != *(eF132)[0] || *(sF132)[1] != *(eF132)[1] {
+					t.Errorf("f13.0.f13.0.f6: expected %v, got %v", vals(eF132), vals(sF132))
+				}
+			}
+		}
+	}
+	if s.F14 != e.F14 {
+		t.Errorf("f14: expected %v, got %v", e.F14, s.F14)
+	}
+	if s.F15 != e.F15 {
+		t.Errorf("f15: expected %v, got %v", e.F15, s.F15)
+	}
+	if s.F16 == nil {
+		t.Errorf("f16: nil")
+	} else if len(s.F16) != len(e.F16) {
+		t.Errorf("f16: expected len %d, got %d", len(e.F16), len(s.F16))
+	} else if !reflect.DeepEqual(s.F16, e.F16) {
+		t.Errorf("f16: expected %v, got %v", e.F16, s.F16)
+	}
+	if s.F17 != e.F17 {
+		t.Errorf("f17: expected %v, got %v", e.F17, s.F17)
+	}
+	if s.F18 != e.F18 {
+		t.Errorf("f18: expected %v, got %v", e.F18, s.F18)
+	}
+	if *s.F19 != *e.F19 {
+		t.Errorf("f19: expected %v, got %v", *e.F19, *s.F19)
+	}
+	if s.F20 == nil {
+		t.Errorf("f20: nil")
+	} else if len(s.F20) != len(e.F20) {
+		t.Errorf("f20: expected %v, got %v", e.F20, s.F20)
+	} else if !reflect.DeepEqual(s.F20, e.F20) {
+		t.Errorf("f20: expected %v, got %v", e.F20, s.F20)
+	}
+	if s.F21 == nil {
+		t.Errorf("f21: nil")
+	} else if len(s.F21) != len(e.F21) {
+		t.Errorf("f21: expected length %d, got %d", len(e.F21), len(s.F21))
+	} else if !reflect.DeepEqual(s.F21, e.F21) {
+		t.Errorf("f21: expected %v, got %v", e.F21, s.F21)
+	}
+}
+
+func BenchmarkAll(b *testing.B) {
+	v := map[string][]string{
+		"f1":             {"1"},
+		"f2":             {"2"},
+		"f3":             {"31", "32"},
+		"f4":             {"41", "42"},
+		"f5":             {"51", "52"},
+		"f6":             {"61", "62"},
+		"f7.f1":          {"71", "72"},
+		"f8.f8.f7.f1":    {"81", "82"},
+		"f9":             {"9"},
+		"f10.0.f10.0.f6": {"101", "102"},
+		"f10.0.f10.1.f6": {"103", "104"},
+		"f11.0.f11.0.f6": {"111", "112"},
+		"f11.0.f11.1.f6": {"113", "114"},
+		"f12.0.f12.0.f6": {"121", "122"},
+		"f12.0.f12.1.f6": {"123", "124"},
+		"f13.0.f13.0.f6": {"131", "132"},
+		"f13.0.f13.1.f6": {"133", "134"},
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		s := &S1{}
+		_ = NewDecoder().Decode(s, v)
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S3 struct {
+	F01 bool
+	F02 float32
+	F03 float64
+	F04 int
+	F05 int8
+	F06 int16
+	F07 int32
+	F08 int64
+	F09 string
+	F10 uint
+	F11 uint8
+	F12 uint16
+	F13 uint32
+	F14 uint64
+}
+
+func TestDefaultConverters(t *testing.T) {
+	v := map[string][]string{
+		"F01": {"true"},
+		"F02": {"4.2"},
+		"F03": {"4.3"},
+		"F04": {"-42"},
+		"F05": {"-43"},
+		"F06": {"-44"},
+		"F07": {"-45"},
+		"F08": {"-46"},
+		"F09": {"foo"},
+		"F10": {"42"},
+		"F11": {"43"},
+		"F12": {"44"},
+		"F13": {"45"},
+		"F14": {"46"},
+	}
+	e := S3{
+		F01: true,
+		F02: 4.2,
+		F03: 4.3,
+		F04: -42,
+		F05: -43,
+		F06: -44,
+		F07: -45,
+		F08: -46,
+		F09: "foo",
+		F10: 42,
+		F11: 43,
+		F12: 44,
+		F13: 45,
+		F14: 46,
+	}
+	s := &S3{}
+	_ = NewDecoder().Decode(s, v)
+	if s.F01 != e.F01 {
+		t.Errorf("F01: expected %v, got %v", e.F01, s.F01)
+	}
+	if s.F02 != e.F02 {
+		t.Errorf("F02: expected %v, got %v", e.F02, s.F02)
+	}
+	if s.F03 != e.F03 {
+		t.Errorf("F03: expected %v, got %v", e.F03, s.F03)
+	}
+	if s.F04 != e.F04 {
+		t.Errorf("F04: expected %v, got %v", e.F04, s.F04)
+	}
+	if s.F05 != e.F05 {
+		t.Errorf("F05: expected %v, got %v", e.F05, s.F05)
+	}
+	if s.F06 != e.F06 {
+		t.Errorf("F06: expected %v, got %v", e.F06, s.F06)
+	}
+	if s.F07 != e.F07 {
+		t.Errorf("F07: expected %v, got %v", e.F07, s.F07)
+	}
+	if s.F08 != e.F08 {
+		t.Errorf("F08: expected %v, got %v", e.F08, s.F08)
+	}
+	if s.F09 != e.F09 {
+		t.Errorf("F09: expected %v, got %v", e.F09, s.F09)
+	}
+	if s.F10 != e.F10 {
+		t.Errorf("F10: expected %v, got %v", e.F10, s.F10)
+	}
+	if s.F11 != e.F11 {
+		t.Errorf("F11: expected %v, got %v", e.F11, s.F11)
+	}
+	if s.F12 != e.F12 {
+		t.Errorf("F12: expected %v, got %v", e.F12, s.F12)
+	}
+	if s.F13 != e.F13 {
+		t.Errorf("F13: expected %v, got %v", e.F13, s.F13)
+	}
+	if s.F14 != e.F14 {
+		t.Errorf("F14: expected %v, got %v", e.F14, s.F14)
+	}
+}
+
+func TestOn(t *testing.T) {
+	v := map[string][]string{
+		"F01": {"on"},
+	}
+	s := S3{}
+	err := NewDecoder().Decode(&s, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.F01 {
+		t.Fatal("Value was not set to true")
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+func TestInlineStruct(t *testing.T) {
+	s1 := &struct {
+		F01 bool
+	}{}
+	s2 := &struct {
+		F01 int
+	}{}
+	v1 := map[string][]string{
+		"F01": {"true"},
+	}
+	v2 := map[string][]string{
+		"F01": {"42"},
+	}
+	decoder := NewDecoder()
+	_ = decoder.Decode(s1, v1)
+	if s1.F01 != true {
+		t.Errorf("s1: expected %v, got %v", true, s1.F01)
+	}
+	_ = decoder.Decode(s2, v2)
+	if s2.F01 != 42 {
+		t.Errorf("s2: expected %v, got %v", 42, s2.F01)
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type Foo struct {
+	F01 int
+	F02 Bar
+	Bif []Baz
+}
+
+type Bar struct {
+	F01 string
+	F02 string
+	F03 string
+	F14 string
+	S05 string
+	Str string
+}
+
+type Baz struct {
+	F99 []string
+}
+
+func TestSimpleExample(t *testing.T) {
+	data := map[string][]string{
+		"F01":       {"1"},
+		"F02.F01":   {"S1"},
+		"F02.F02":   {"S2"},
+		"F02.F03":   {"S3"},
+		"F02.F14":   {"S4"},
+		"F02.S05":   {"S5"},
+		"F02.Str":   {"Str"},
+		"Bif.0.F99": {"A", "B", "C"},
+	}
+
+	e := &Foo{
+		F01: 1,
+		F02: Bar{
+			F01: "S1",
+			F02: "S2",
+			F03: "S3",
+			F14: "S4",
+			S05: "S5",
+			Str: "Str",
+		},
+		Bif: []Baz{{
+			F99: []string{"A", "B", "C"}},
+		},
+	}
+
+	s := &Foo{}
+	_ = NewDecoder().Decode(s, data)
+
+	if s.F01 != e.F01 {
+		t.Errorf("F01: expected %v, got %v", e.F01, s.F01)
+	}
+	if s.F02.F01 != e.F02.F01 {
+		t.Errorf("F02.F01: expected %v, got %v", e.F02.F01, s.F02.F01)
+	}
+	if s.F02.F02 != e.F02.F02 {
+		t.Errorf("F02.F02: expected %v, got %v", e.F02.F02, s.F02.F02)
+	}
+	if s.F02.F03 != e.F02.F03 {
+		t.Errorf("F02.F03: expected %v, got %v", e.F02.F03, s.F02.F03)
+	}
+	if s.F02.F14 != e.F02.F14 {
+		t.Errorf("F02.F14: expected %v, got %v", e.F02.F14, s.F02.F14)
+	}
+	if s.F02.S05 != e.F02.S05 {
+		t.Errorf("F02.S05: expected %v, got %v", e.F02.S05, s.F02.S05)
+	}
+	if s.F02.Str != e.F02.Str {
+		t.Errorf("F02.Str: expected %v, got %v", e.F02.Str, s.F02.Str)
+	}
+	if len(s.Bif) != len(e.Bif) {
+		t.Errorf("Bif len: expected %d, got %d", len(e.Bif), len(s.Bif))
+	} else {
+		if len(s.Bif[0].F99) != len(e.Bif[0].F99) {
+			t.Errorf("Bif[0].F99 len: expected %d, got %d", len(e.Bif[0].F99), len(s.Bif[0].F99))
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S4 struct {
+	F01 int64
+	F02 float64
+	F03 bool
+	F04 rudeBool
+}
+
+func TestConversionError(t *testing.T) {
+	data := map[string][]string{
+		"F01": {"foo"},
+		"F02": {"bar"},
+		"F03": {"baz"},
+		"F04": {"not-a-yes-or-nope"},
+	}
+	s := &S4{}
+	e := NewDecoder().Decode(s, data)
+
+	m := e.(MultiError)
+	if len(m) != 4 {
+		t.Errorf("Expected 3 errors, got %v", m)
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S5 struct {
+	F01 []string
+}
+
+func TestEmptyValue(t *testing.T) {
+	data := map[string][]string{
+		"F01": {"", "foo"},
+	}
+	s := &S5{}
+	NewDecoder().Decode(s, data)
+	if len(s.F01) != 1 {
+		t.Errorf("Expected 1 values in F01")
+	}
+}
+
+func TestEmptyValueZeroEmpty(t *testing.T) {
+	data := map[string][]string{
+		"F01": {"", "foo"},
+	}
+	s := S5{}
+	d := NewDecoder()
+	d.ZeroEmpty(true)
+	err := d.Decode(&s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.F01) != 2 {
+		t.Errorf("Expected 1 values in F01")
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S6 struct {
+	id string
+}
+
+func TestUnexportedField(t *testing.T) {
+	data := map[string][]string{
+		"id": {"identifier"},
+	}
+	s := &S6{}
+	NewDecoder().Decode(s, data)
+	if s.id != "" {
+		t.Errorf("Unexported field expected to be ignored")
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S7 struct {
+	ID string
+}
+
+func TestMultipleValues(t *testing.T) {
+	data := map[string][]string{
+		"ID": {"0", "1"},
+	}
+
+	s := S7{}
+	NewDecoder().Decode(&s, data)
+	if s.ID != "1" {
+		t.Errorf("Last defined value must be used when multiple values for same field are provided")
+	}
+}
+
+type S8 struct {
+	ID string `json:"id"`
+}
+
+func TestSetAliasTag(t *testing.T) {
+	data := map[string][]string{
+		"id": {"foo"},
+	}
+
+	s := S8{}
+	dec := NewDecoder()
+	dec.SetAliasTag("json")
+	dec.Decode(&s, data)
+	if s.ID != "foo" {
+		t.Fatalf("Bad value: got %q, want %q", s.ID, "foo")
+	}
+}
+
+func TestZeroEmpty(t *testing.T) {
+	data := map[string][]string{
+		"F01": {""},
+		"F03": {"true"},
+	}
+	s := S4{1, 1, false, false}
+	d := NewDecoder()
+	d.ZeroEmpty(true)
+
+	err := d.Decode(&s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.F01 != 0 {
+		t.Errorf("F01: got %v, want %v", s.F01, 0)
+	}
+	if s.F02 != 1 {
+		t.Errorf("F02: got %v, want %v", s.F02, 1)
+	}
+	if s.F03 != true {
+		t.Errorf("F03: got %v, want %v", s.F03, true)
+	}
+}
+
+func TestNoZeroEmpty(t *testing.T) {
+	data := map[string][]string{
+		"F01": {""},
+		"F03": {"true"},
+	}
+	s := S4{1, 1, false, false}
+	d := NewDecoder()
+	d.ZeroEmpty(false)
+	err := d.Decode(&s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.F01 != 1 {
+		t.Errorf("F01: got %v, want %v", s.F01, 1)
+	}
+	if s.F02 != 1 {
+		t.Errorf("F02: got %v, want %v", s.F02, 1)
+	}
+	if s.F03 != true {
+		t.Errorf("F03: got %v, want %v", s.F03, true)
+	}
+	if s.F04 != false {
+		t.Errorf("F04: got %v, want %v", s.F04, false)
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S9 struct {
+	Id string
+}
+
+type S10 struct {
+	S9
+}
+
+func TestEmbeddedField(t *testing.T) {
+	data := map[string][]string{
+		"Id": {"identifier"},
+	}
+	s := &S10{}
+	NewDecoder().Decode(s, data)
+	if s.Id != "identifier" {
+		t.Errorf("Missing support for embedded fields")
+	}
+}
+
+type S11 struct {
+	S10
+}
+
+func TestMultipleLevelEmbeddedField(t *testing.T) {
+	data := map[string][]string{
+		"Id": {"identifier"},
+	}
+	s := &S11{}
+	err := NewDecoder().Decode(s, data)
+	if s.Id != "identifier" {
+		t.Errorf("Missing support for multiple-level embedded fields (%v)", err)
+	}
+}
+
+func TestInvalidPath(t *testing.T) {
+	data := map[string][]string{
+		"Foo.Bar": {"baz"},
+	}
+	s := S9{}
+	err := NewDecoder().Decode(&s, data)
+	expectedErr := `schema: invalid path "Foo.Bar"`
+	if err.Error() != expectedErr {
+		t.Fatalf("got %q, want %q", err, expectedErr)
+	}
+}
+
+func TestInvalidPathIgnoreUnknownKeys(t *testing.T) {
+	data := map[string][]string{
+		"Foo.Bar": {"baz"},
+	}
+	s := S9{}
+	dec := NewDecoder()
+	dec.IgnoreUnknownKeys(true)
+	err := dec.Decode(&s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S1NT struct {
+	F1  int
+	F2  *int
+	F3  []int
+	F4  []*int
+	F5  *[]int
+	F6  *[]*int
+	F7  S2
+	F8  *S1
+	F9  int `schema:"-"`
+	F10 []S1
+	F11 []*S1
+	F12 *[]S1
+	F13 *[]*S1
+}
+
+func TestAllNT(t *testing.T) {
+	v := map[string][]string{
+		"f1":             {"1"},
+		"f2":             {"2"},
+		"f3":             {"31", "32"},
+		"f4":             {"41", "42"},
+		"f5":             {"51", "52"},
+		"f6":             {"61", "62"},
+		"f7.f1":          {"71", "72"},
+		"f8.f8.f7.f1":    {"81", "82"},
+		"f9":             {"9"},
+		"f10.0.f10.0.f6": {"101", "102"},
+		"f10.0.f10.1.f6": {"103", "104"},
+		"f11.0.f11.0.f6": {"111", "112"},
+		"f11.0.f11.1.f6": {"113", "114"},
+		"f12.0.f12.0.f6": {"121", "122"},
+		"f12.0.f12.1.f6": {"123", "124"},
+		"f13.0.f13.0.f6": {"131", "132"},
+		"f13.0.f13.1.f6": {"133", "134"},
+	}
+	f2 := 2
+	f41, f42 := 41, 42
+	f61, f62 := 61, 62
+	f71, f72 := 71, 72
+	f81, f82 := 81, 82
+	f101, f102, f103, f104 := 101, 102, 103, 104
+	f111, f112, f113, f114 := 111, 112, 113, 114
+	f121, f122, f123, f124 := 121, 122, 123, 124
+	f131, f132, f133, f134 := 131, 132, 133, 134
+	e := S1NT{
+		F1: 1,
+		F2: &f2,
+		F3: []int{31, 32},
+		F4: []*int{&f41, &f42},
+		F5: &[]int{51, 52},
+		F6: &[]*int{&f61, &f62},
+		F7: S2{
+			F01: &[]*int{&f71, &f72},
+		},
+		F8: &S1{
+			F08: &S1{
+				F07: S2{
+					F01: &[]*int{&f81, &f82},
+				},
+			},
+		},
+		F9: 0,
+		F10: []S1{
+			S1{
+				F10: []S1{
+					S1{F06: &[]*int{&f101, &f102}},
+					S1{F06: &[]*int{&f103, &f104}},
+				},
+			},
+		},
+		F11: []*S1{
+			&S1{
+				F11: []*S1{
+					&S1{F06: &[]*int{&f111, &f112}},
+					&S1{F06: &[]*int{&f113, &f114}},
+				},
+			},
+		},
+		F12: &[]S1{
+			S1{
+				F12: &[]S1{
+					S1{F06: &[]*int{&f121, &f122}},
+					S1{F06: &[]*int{&f123, &f124}},
+				},
+			},
+		},
+		F13: &[]*S1{
+			&S1{
+				F13: &[]*S1{
+					&S1{F06: &[]*int{&f131, &f132}},
+					&S1{F06: &[]*int{&f133, &f134}},
+				},
+			},
+		},
+	}
+
+	s := &S1NT{}
+	_ = NewDecoder().Decode(s, v)
+
+	vals := func(values []*int) []int {
+		r := make([]int, len(values))
+		for k, v := range values {
+			r[k] = *v
+		}
+		return r
+	}
+
+	if s.F1 != e.F1 {
+		t.Errorf("f1: expected %v, got %v", e.F1, s.F1)
+	}
+	if s.F2 == nil {
+		t.Errorf("f2: expected %v, got nil", *e.F2)
+	} else if *s.F2 != *e.F2 {
+		t.Errorf("f2: expected %v, got %v", *e.F2, *s.F2)
+	}
+	if s.F3 == nil {
+		t.Errorf("f3: expected %v, got nil", e.F3)
+	} else if len(s.F3) != 2 || s.F3[0] != e.F3[0] || s.F3[1] != e.F3[1] {
+		t.Errorf("f3: expected %v, got %v", e.F3, s.F3)
+	}
+	if s.F4 == nil {
+		t.Errorf("f4: expected %v, got nil", e.F4)
+	} else {
+		if len(s.F4) != 2 || *(s.F4)[0] != *(e.F4)[0] || *(s.F4)[1] != *(e.F4)[1] {
+			t.Errorf("f4: expected %v, got %v", vals(e.F4), vals(s.F4))
+		}
+	}
+	if s.F5 == nil {
+		t.Errorf("f5: expected %v, got nil", e.F5)
+	} else {
+		sF5, eF5 := *s.F5, *e.F5
+		if len(sF5) != 2 || sF5[0] != eF5[0] || sF5[1] != eF5[1] {
+			t.Errorf("f5: expected %v, got %v", eF5, sF5)
+		}
+	}
+	if s.F6 == nil {
+		t.Errorf("f6: expected %v, got nil", vals(*e.F6))
+	} else {
+		sF6, eF6 := *s.F6, *e.F6
+		if len(sF6) != 2 || *(sF6)[0] != *(eF6)[0] || *(sF6)[1] != *(eF6)[1] {
+			t.Errorf("f6: expected %v, got %v", vals(eF6), vals(sF6))
+		}
+	}
+	if s.F7.F01 == nil {
+		t.Errorf("f7.f1: expected %v, got nil", vals(*e.F7.F01))
+	} else {
+		sF7, eF7 := *s.F7.F01, *e.F7.F01
+		if len(sF7) != 2 || *(sF7)[0] != *(eF7)[0] || *(sF7)[1] != *(eF7)[1] {
+			t.Errorf("f7.f1: expected %v, got %v", vals(eF7), vals(sF7))
+		}
+	}
+	if s.F8 == nil {
+		t.Errorf("f8: got nil")
+	} else if s.F8.F08 == nil {
+		t.Errorf("f8.f8: got nil")
+	} else if s.F8.F08.F07.F01 == nil {
+		t.Errorf("f8.f8.f7.f1: expected %v, got nil", vals(*e.F8.F08.F07.F01))
+	} else {
+		sF8, eF8 := *s.F8.F08.F07.F01, *e.F8.F08.F07.F01
+		if len(sF8) != 2 || *(sF8)[0] != *(eF8)[0] || *(sF8)[1] != *(eF8)[1] {
+			t.Errorf("f8.f8.f7.f1: expected %v, got %v", vals(eF8), vals(sF8))
+		}
+	}
+	if s.F9 != e.F9 {
+		t.Errorf("f9: expected %v, got %v", e.F9, s.F9)
+	}
+	if s.F10 == nil {
+		t.Errorf("f10: got nil")
+	} else if len(s.F10) != 1 {
+		t.Errorf("f10: expected 1 element, got %v", s.F10)
+	} else {
+		if len(s.F10[0].F10) != 2 {
+			t.Errorf("f10.0.f10: expected 1 element, got %v", s.F10[0].F10)
+		} else {
+			sF10, eF10 := *s.F10[0].F10[0].F06, *e.F10[0].F10[0].F06
+			if sF10 == nil {
+				t.Errorf("f10.0.f10.0.f6: expected %v, got nil", vals(eF10))
+			} else {
+				if len(sF10) != 2 || *(sF10)[0] != *(eF10)[0] || *(sF10)[1] != *(eF10)[1] {
+					t.Errorf("f10.0.f10.0.f6: expected %v, got %v", vals(eF10), vals(sF10))
+				}
+			}
+			sF10, eF10 = *s.F10[0].F10[1].F06, *e.F10[0].F10[1].F06
+			if sF10 == nil {
+				t.Errorf("f10.0.f10.0.f6: expected %v, got nil", vals(eF10))
+			} else {
+				if len(sF10) != 2 || *(sF10)[0] != *(eF10)[0] || *(sF10)[1] != *(eF10)[1] {
+					t.Errorf("f10.0.f10.0.f6: expected %v, got %v", vals(eF10), vals(sF10))
+				}
+			}
+		}
+	}
+	if s.F11 == nil {
+		t.Errorf("f11: got nil")
+	} else if len(s.F11) != 1 {
+		t.Errorf("f11: expected 1 element, got %v", s.F11)
+	} else {
+		if len(s.F11[0].F11) != 2 {
+			t.Errorf("f11.0.f11: expected 1 element, got %v", s.F11[0].F11)
+		} else {
+			sF11, eF11 := *s.F11[0].F11[0].F06, *e.F11[0].F11[0].F06
+			if sF11 == nil {
+				t.Errorf("f11.0.f11.0.f6: expected %v, got nil", vals(eF11))
+			} else {
+				if len(sF11) != 2 || *(sF11)[0] != *(eF11)[0] || *(sF11)[1] != *(eF11)[1] {
+					t.Errorf("f11.0.f11.0.f6: expected %v, got %v", vals(eF11), vals(sF11))
+				}
+			}
+			sF11, eF11 = *s.F11[0].F11[1].F06, *e.F11[0].F11[1].F06
+			if sF11 == nil {
+				t.Errorf("f11.0.f11.0.f6: expected %v, got nil", vals(eF11))
+			} else {
+				if len(sF11) != 2 || *(sF11)[0] != *(eF11)[0] || *(sF11)[1] != *(eF11)[1] {
+					t.Errorf("f11.0.f11.0.f6: expected %v, got %v", vals(eF11), vals(sF11))
+				}
+			}
+		}
+	}
+	if s.F12 == nil {
+		t.Errorf("f12: got nil")
+	} else if len(*s.F12) != 1 {
+		t.Errorf("f12: expected 1 element, got %v", *s.F12)
+	} else {
+		sF12, eF12 := *(s.F12), *(e.F12)
+		if len(*sF12[0].F12) != 2 {
+			t.Errorf("f12.0.f12: expected 1 element, got %v", *sF12[0].F12)
+		} else {
+			sF122, eF122 := *(*sF12[0].F12)[0].F06, *(*eF12[0].F12)[0].F06
+			if sF122 == nil {
+				t.Errorf("f12.0.f12.0.f6: expected %v, got nil", vals(eF122))
+			} else {
+				if len(sF122) != 2 || *(sF122)[0] != *(eF122)[0] || *(sF122)[1] != *(eF122)[1] {
+					t.Errorf("f12.0.f12.0.f6: expected %v, got %v", vals(eF122), vals(sF122))
+				}
+			}
+			sF122, eF122 = *(*sF12[0].F12)[1].F06, *(*eF12[0].F12)[1].F06
+			if sF122 == nil {
+				t.Errorf("f12.0.f12.0.f6: expected %v, got nil", vals(eF122))
+			} else {
+				if len(sF122) != 2 || *(sF122)[0] != *(eF122)[0] || *(sF122)[1] != *(eF122)[1] {
+					t.Errorf("f12.0.f12.0.f6: expected %v, got %v", vals(eF122), vals(sF122))
+				}
+			}
+		}
+	}
+	if s.F13 == nil {
+		t.Errorf("f13: got nil")
+	} else if len(*s.F13) != 1 {
+		t.Errorf("f13: expected 1 element, got %v", *s.F13)
+	} else {
+		sF13, eF13 := *(s.F13), *(e.F13)
+		if len(*sF13[0].F13) != 2 {
+			t.Errorf("f13.0.f13: expected 1 element, got %v", *sF13[0].F13)
+		} else {
+			sF132, eF132 := *(*sF13[0].F13)[0].F06, *(*eF13[0].F13)[0].F06
+			if sF132 == nil {
+				t.Errorf("f13.0.f13.0.f6: expected %v, got nil", vals(eF132))
+			} else {
+				if len(sF132) != 2 || *(sF132)[0] != *(eF132)[0] || *(sF132)[1] != *(eF132)[1] {
+					t.Errorf("f13.0.f13.0.f6: expected %v, got %v", vals(eF132), vals(sF132))
+				}
+			}
+			sF132, eF132 = *(*sF13[0].F13)[1].F06, *(*eF13[0].F13)[1].F06
+			if sF132 == nil {
+				t.Errorf("f13.0.f13.0.f6: expected %v, got nil", vals(eF132))
+			} else {
+				if len(sF132) != 2 || *(sF132)[0] != *(eF132)[0] || *(sF132)[1] != *(eF132)[1] {
+					t.Errorf("f13.0.f13.0.f6: expected %v, got %v", vals(eF132), vals(sF132))
+				}
+			}
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S12A struct {
+	ID []int
+}
+
+func TestCSVSlice(t *testing.T) {
+	data := map[string][]string{
+		"ID": {"0,1"},
+	}
+
+	s := S12A{}
+	NewDecoder().Decode(&s, data)
+	if len(s.ID) != 2 {
+		t.Errorf("Expected two values in the result list, got %+v", s.ID)
+	}
+	if s.ID[0] != 0 || s.ID[1] != 1 {
+		t.Errorf("Expected []{0, 1} got %+v", s)
+	}
+}
+
+type S12B struct {
+	ID []string
+}
+
+//Decode should not split on , into a slice for string only
+func TestCSVStringSlice(t *testing.T) {
+	data := map[string][]string{
+		"ID": {"0,1"},
+	}
+
+	s := S12B{}
+	NewDecoder().Decode(&s, data)
+	if len(s.ID) != 1 {
+		t.Errorf("Expected one value in the result list, got %+v", s.ID)
+	}
+	if s.ID[0] != "0,1" {
+		t.Errorf("Expected []{0, 1} got %+v", s)
+	}
+}
+
+//Invalid data provided by client should not panic (github issue 33)
+func TestInvalidDataProvidedByClient(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panicked calling decoder.Decode: %v", r)
+		}
+	}()
+
+	type S struct {
+		f string
+	}
+
+	data := map[string][]string{
+		"f.f": {"v"},
+	}
+
+	err := NewDecoder().Decode(new(S), data)
+	if err == nil {
+		t.Errorf("invalid path in decoder.Decode should return an error.")
+	}
+}
+
+// underlying cause of error in issue 33
+func TestInvalidPathInCacheParsePath(t *testing.T) {
+	type S struct {
+		f string
+	}
+
+	typ := reflect.ValueOf(new(S)).Elem().Type()
+	c := newCache()
+	_, err := c.parsePath("f.f", typ)
+	if err == nil {
+		t.Errorf("invalid path in cache.parsePath should return an error.")
+	}
+}
+
+// issue 32
+func TestDecodeToTypedField(t *testing.T) {
+	type Aa bool
+	s1 := &struct{ Aa }{}
+	v1 := map[string][]string{"Aa": {"true"}}
+	NewDecoder().Decode(s1, v1)
+	if s1.Aa != Aa(true) {
+		t.Errorf("s1: expected %v, got %v", true, s1.Aa)
+	}
+}
+
+// issue 37
+func TestRegisterConverter(t *testing.T) {
+	type Aa int
+	type Bb int
+	s1 := &struct {
+		Aa
+		Bb
+	}{}
+	decoder := NewDecoder()
+
+	decoder.RegisterConverter(s1.Aa, func(s string) reflect.Value { return reflect.ValueOf(1) })
+	decoder.RegisterConverter(s1.Bb, func(s string) reflect.Value { return reflect.ValueOf(2) })
+
+	v1 := map[string][]string{"Aa": {"4"}, "Bb": {"5"}}
+	decoder.Decode(s1, v1)
+
+	if s1.Aa != Aa(1) {
+		t.Errorf("s1.Aa: expected %v, got %v", 1, s1.Aa)
+	}
+	if s1.Bb != Bb(2) {
+		t.Errorf("s1.Bb: expected %v, got %v", 2, s1.Bb)
+	}
+}
+
+// Issue #40
+func TestRegisterConverterSlice(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.RegisterConverter([]string{}, func(input string) reflect.Value {
+		return reflect.ValueOf(strings.Split(input, ","))
+	})
+
+	result := struct {
+		Multiple []string `schema:"multiple"`
+	}{}
+
+	expected := []string{"one", "two", "three"}
+	decoder.Decode(&result, map[string][]string{
+		"multiple": []string{"one,two,three"},
+	})
+	for i := range expected {
+		if got, want := expected[i], result.Multiple[i]; got != want {
+			t.Errorf("%d: got %s, want %s", i, got, want)
+		}
+	}
+}
+
+func TestRegisterConverterMap(t *testing.T) {
+	decoder := NewDecoder()
+	decoder.IgnoreUnknownKeys(false)
+	decoder.RegisterConverter(map[string]string{}, func(input string) reflect.Value {
+		m := make(map[string]string)
+		for _, pair := range strings.Split(input, ",") {
+			parts := strings.Split(pair, ":")
+			switch len(parts) {
+			case 2:
+				m[parts[0]] = parts[1]
+			}
+		}
+		return reflect.ValueOf(m)
+	})
+
+	result := struct {
+		Multiple map[string]string `schema:"multiple"`
+	}{}
+
+	err := decoder.Decode(&result, map[string][]string{
+		"multiple": []string{"a:one,b:two"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[string]string{"a": "one", "b": "two"}
+	for k, v := range expected {
+		got, ok := result.Multiple[k]
+		if !ok {
+			t.Fatalf("got %v, want %v", result.Multiple, expected)
+		}
+		if got != v {
+			t.Errorf("got %s, want %s", got, v)
+		}
+	}
+}
+
+type S13 struct {
+	Value []S14
+}
+
+type S14 struct {
+	F1 string
+	F2 string
+}
+
+func (n *S14) UnmarshalText(text []byte) error {
+	textParts := strings.Split(string(text), " ")
+	if len(textParts) < 2 {
+		return errors.New("Not a valid name!")
+	}
+
+	n.F1, n.F2 = textParts[0], textParts[len(textParts)-1]
+	return nil
+}
+
+type S15 struct {
+	Value []S16
+}
+
+type S16 struct {
+	F1 string
+	F2 string
+}
+
+func TestCustomTypeSlice(t *testing.T) {
+	data := map[string][]string{
+		"Value.0": []string{"Louisa May Alcott"},
+		"Value.1": []string{"Florence Nightingale"},
+		"Value.2": []string{"Clara Barton"},
+	}
+
+	s := S13{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s.Value) != 3 {
+		t.Fatalf("Expected 3 values in the result list, got %+v", s.Value)
+	}
+	if s.Value[0].F1 != "Louisa" || s.Value[0].F2 != "Alcott" {
+		t.Errorf("Expected S14{'Louisa', 'Alcott'} got %+v", s.Value[0])
+	}
+	if s.Value[1].F1 != "Florence" || s.Value[1].F2 != "Nightingale" {
+		t.Errorf("Expected S14{'Florence', 'Nightingale'} got %+v", s.Value[1])
+	}
+	if s.Value[2].F1 != "Clara" || s.Value[2].F2 != "Barton" {
+		t.Errorf("Expected S14{'Clara', 'Barton'} got %+v", s.Value[2])
+	}
+}
+
+func TestCustomTypeSliceWithError(t *testing.T) {
+	data := map[string][]string{
+		"Value.0": []string{"Louisa May Alcott"},
+		"Value.1": []string{"Florence Nightingale"},
+		"Value.2": []string{"Clara"},
+	}
+
+	s := S13{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err == nil {
+		t.Error("Not detecting error in conversion")
+	}
+}
+
+func TestNoTextUnmarshalerTypeSlice(t *testing.T) {
+	data := map[string][]string{
+		"Value.0": []string{"Louisa May Alcott"},
+		"Value.1": []string{"Florence Nightingale"},
+		"Value.2": []string{"Clara Barton"},
+	}
+
+	s := S15{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err == nil {
+		t.Error("Not detecting when there's no converter")
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+type S17 struct {
+	Value S14
+}
+
+type S18 struct {
+	Value S16
+}
+
+func TestCustomType(t *testing.T) {
+	data := map[string][]string{
+		"Value": []string{"Louisa May Alcott"},
+	}
+
+	s := S17{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Value.F1 != "Louisa" || s.Value.F2 != "Alcott" {
+		t.Errorf("Expected S14{'Louisa', 'Alcott'} got %+v", s.Value)
+	}
+}
+
+func TestCustomTypeWithError(t *testing.T) {
+	data := map[string][]string{
+		"Value": []string{"Louisa"},
+	}
+
+	s := S17{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err == nil {
+		t.Error("Not detecting error in conversion")
+	}
+}
+
+func TestNoTextUnmarshalerType(t *testing.T) {
+	data := map[string][]string{
+		"Value": []string{"Louisa May Alcott"},
+	}
+
+	s := S18{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err == nil {
+		t.Error("Not detecting when there's no converter")
+	}
+}
+
+func TestExpectedType(t *testing.T) {
+	data := map[string][]string{
+		"bools":   []string{"1", "a"},
+		"date":    []string{"invalid"},
+		"Foo.Bar": []string{"a", "b"},
+	}
+
+	type B struct {
+		Bar *int
+	}
+	type A struct {
+		Bools []bool    `schema:"bools"`
+		Date  time.Time `schema:"date"`
+		Foo   B
+	}
+
+	a := A{}
+
+	err := NewDecoder().Decode(&a, data)
+
+	e := err.(MultiError)["bools"].(ConversionError)
+	if e.Type != reflect.TypeOf(false) && e.Index == 1 {
+		t.Errorf("Expected bool, index: 1 got %+v, index: %d", e.Type, e.Index)
+	}
+	e = err.(MultiError)["date"].(ConversionError)
+	if e.Type != reflect.TypeOf(time.Time{}) {
+		t.Errorf("Expected time.Time got %+v", e.Type)
+	}
+	e = err.(MultiError)["Foo.Bar"].(ConversionError)
+	if e.Type != reflect.TypeOf(0) {
+		t.Errorf("Expected int got %+v", e.Type)
+	}
+}
+
+type R1 struct {
+	A string `schema:"a,required"`
+	B struct {
+		C int     `schema:"c,required"`
+		D float64 `schema:"d"`
+		E string  `schema:"e,required"`
+	} `schema:"b"`
+	F []string `schema:"f,required"`
+	G []int    `schema:"g,othertag"`
+	H bool     `schema:"h,required"`
+}
+
+func TestRequiredField(t *testing.T) {
+	var a R1
+	v := map[string][]string{
+		"a":   []string{"bbb"},
+		"b.c": []string{"88"},
+		"b.d": []string{"9"},
+		"f":   []string{""},
+		"h":   []string{"true"},
+	}
+	err := NewDecoder().Decode(&a, v)
+	if err == nil {
+		t.Errorf("error nil, b.e is empty expect")
+		return
+	}
+	// b.e empty
+	v["b.e"] = []string{""} // empty string
+	err = NewDecoder().Decode(&a, v)
+	if err == nil {
+		t.Errorf("error nil, b.e is empty expect")
+		return
+	}
+
+	// all fields ok
+	v["b.e"] = []string{"nonempty"}
+	err = NewDecoder().Decode(&a, v)
+	if err != nil {
+		t.Errorf("error: %v", err)
+		return
+	}
+
+	// set f empty
+	v["f"] = []string{}
+	err = NewDecoder().Decode(&a, v)
+	if err == nil {
+		t.Errorf("error nil, f is empty expect")
+		return
+	}
+	v["f"] = []string{"nonempty"}
+
+	// b.c type int with empty string
+	v["b.c"] = []string{""}
+	err = NewDecoder().Decode(&a, v)
+	if err == nil {
+		t.Errorf("error nil, b.c is empty expect")
+		return
+	}
+	v["b.c"] = []string{"3"}
+
+	// h type bool with empty string
+	v["h"] = []string{""}
+	err = NewDecoder().Decode(&a, v)
+	if err == nil {
+		t.Errorf("error nil, h is empty expect")
+		return
+	}
+}
+
+type AS1 struct {
+	A int32 `schema:"a,required"`
+	E int32 `schema:"e,required"`
+}
+type AS2 struct {
+	AS1
+	B string `schema:"b,required"`
+}
+type AS3 struct {
+	C int32 `schema:"c"`
+}
+
+type AS4 struct {
+	AS3
+	D string `schema:"d"`
+}
+
+func TestAnonymousStructField(t *testing.T) {
+	patterns := []map[string][]string{
+		{
+			"a": {"1"},
+			"e": {"2"},
+			"b": {"abc"},
+		},
+		{
+			"AS1.a": {"1"},
+			"AS1.e": {"2"},
+			"b":     {"abc"},
+		},
+	}
+	for _, v := range patterns {
+		a := AS2{}
+		err := NewDecoder().Decode(&a, v)
+		if err != nil {
+			t.Errorf("Decode failed %s, %#v", err, v)
+			continue
+		}
+		if a.A != 1 {
+			t.Errorf("A: expected %v, got %v", 1, a.A)
+		}
+		if a.E != 2 {
+			t.Errorf("E: expected %v, got %v", 2, a.E)
+		}
+		if a.B != "abc" {
+			t.Errorf("B: expected %v, got %v", "abc", a.B)
+		}
+		if a.AS1.A != 1 {
+			t.Errorf("AS1.A: expected %v, got %v", 1, a.AS1.A)
+		}
+		if a.AS1.E != 2 {
+			t.Errorf("AS1.E: expected %v, got %v", 2, a.AS1.E)
+		}
+	}
+	a := AS2{}
+	err := NewDecoder().Decode(&a, map[string][]string{
+		"e": {"2"},
+		"b": {"abc"},
+	})
+	if err == nil {
+		t.Errorf("error nil, a is empty expect")
+	}
+	patterns = []map[string][]string{
+		{
+			"c": {"1"},
+			"d": {"abc"},
+		},
+		{
+			"AS3.c": {"1"},
+			"d":     {"abc"},
+		},
+	}
+	for _, v := range patterns {
+		a := AS4{}
+		err := NewDecoder().Decode(&a, v)
+		if err != nil {
+			t.Errorf("Decode failed %s, %#v", err, v)
+			continue
+		}
+		if a.C != 1 {
+			t.Errorf("C: expected %v, got %v", 1, a.C)
+		}
+		if a.D != "abc" {
+			t.Errorf("D: expected %v, got %v", "abc", a.D)
+		}
+		if a.AS3.C != 1 {
+			t.Errorf("AS3.C: expected %v, got %v", 1, a.AS3.C)
+		}
+	}
+}
+
+// Test to ensure that a registered converter overrides the default text unmarshaler.
+func TestRegisterConverterOverridesTextUnmarshaler(t *testing.T) {
+	type MyTime time.Time
+	s1 := &struct {
+		MyTime
+	}{}
+	decoder := NewDecoder()
+
+	ts := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	decoder.RegisterConverter(s1.MyTime, func(s string) reflect.Value { return reflect.ValueOf(ts) })
+
+	v1 := map[string][]string{"MyTime": {"4"}, "Bb": {"5"}}
+	decoder.Decode(s1, v1)
+
+	if s1.MyTime != MyTime(ts) {
+		t.Errorf("s1.Aa: expected %v, got %v", ts, s1.MyTime)
+	}
+}

--- a/yunpian/encoder.go
+++ b/yunpian/encoder.go
@@ -1,0 +1,161 @@
+package yunpian
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+type encoderFunc func(reflect.Value) string
+
+// Encoder encodes values from a struct into url.Values.
+type Encoder struct {
+	cache  *cache
+	regenc map[reflect.Type]encoderFunc
+}
+
+// NewEncoder returns a new Encoder with defaults.
+func NewEncoder() *Encoder {
+	return &Encoder{cache: newCache(), regenc: make(map[reflect.Type]encoderFunc)}
+}
+
+// Encode encodes a struct into map[string][]string.
+//
+// Intended for use with url.Values.
+func (e *Encoder) Encode(src interface{}, dst map[string][]string) error {
+	v := reflect.ValueOf(src)
+
+	return e.encode(v, dst)
+}
+
+// RegisterEncoder registers a converter for encoding a custom type.
+func (e *Encoder) RegisterEncoder(value interface{}, encoder func(reflect.Value) string) {
+	e.regenc[reflect.TypeOf(value)] = encoder
+}
+
+// SetAliasTag changes the tag used to locate custom field aliases.
+// The default tag is "schema".
+func (e *Encoder) SetAliasTag(tag string) {
+	e.cache.tag = tag
+}
+
+func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return errors.New("schema: interface must be a struct")
+	}
+	t := v.Type()
+
+	errors := MultiError{}
+
+	for i := 0; i < v.NumField(); i++ {
+		name, opts := fieldAlias(t.Field(i), e.cache.tag)
+		if name == "-" {
+			continue
+		}
+
+		if v.Field(i).Type().Kind() == reflect.Struct {
+			e.encode(v.Field(i), dst)
+			continue
+		}
+
+		encFunc := typeEncoder(v.Field(i).Type(), e.regenc)
+
+		// Encode non-slice types and custom implementations immediately.
+		if encFunc != nil {
+			value := encFunc(v.Field(i))
+			if opts.Contains("omitempty") && v.Field(i).Interface() == reflect.Zero(reflect.TypeOf(v.Field(i).Interface())).Interface() {
+				continue
+			}
+
+			dst[name] = append(dst[name], value)
+			continue
+		}
+
+		if v.Field(i).Type().Kind() == reflect.Slice {
+			encFunc = typeEncoder(v.Field(i).Type().Elem(), e.regenc)
+		}
+
+		if encFunc == nil {
+			errors[v.Field(i).Type().String()] = fmt.Errorf("schema: encoder not found for %v", v.Field(i))
+			continue
+		}
+
+		// Encode a slice.
+		if v.Field(i).Len() == 0 && opts.Contains("omitempty") {
+			continue
+		}
+
+		dst[name] = []string{}
+		for j := 0; j < v.Field(i).Len(); j++ {
+			dst[name] = append(dst[name], encFunc(v.Field(i).Index(j)))
+		}
+	}
+
+	if len(errors) > 0 {
+		return errors
+	}
+	return nil
+}
+
+func typeEncoder(t reflect.Type, reg map[reflect.Type]encoderFunc) encoderFunc {
+	if f, ok := reg[t]; ok {
+		return f
+	}
+
+	switch t.Kind() {
+	case reflect.Bool:
+		return encodeBool
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return encodeInt
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return encodeUint
+	case reflect.Float32:
+		return encodeFloat32
+	case reflect.Float64:
+		return encodeFloat64
+	case reflect.Ptr:
+		f := typeEncoder(t.Elem(), reg)
+		return func(v reflect.Value) string {
+			if v.IsNil() {
+				return "null"
+			}
+			return f(v.Elem())
+		}
+	case reflect.String:
+		return encodeString
+	default:
+		return nil
+	}
+}
+
+func encodeBool(v reflect.Value) string {
+	return strconv.FormatBool(v.Bool())
+}
+
+func encodeInt(v reflect.Value) string {
+	return strconv.FormatInt(int64(v.Int()), 10)
+}
+
+func encodeUint(v reflect.Value) string {
+	return strconv.FormatUint(uint64(v.Uint()), 10)
+}
+
+func encodeFloat(v reflect.Value, bits int) string {
+	return strconv.FormatFloat(v.Float(), 'f', 6, bits)
+}
+
+func encodeFloat32(v reflect.Value) string {
+	return encodeFloat(v, 32)
+}
+
+func encodeFloat64(v reflect.Value) string {
+	return encodeFloat(v, 64)
+}
+
+func encodeString(v reflect.Value) string {
+	return v.String()
+}

--- a/yunpian/encoder_test.go
+++ b/yunpian/encoder_test.go
@@ -1,0 +1,332 @@
+package yunpian
+
+import (
+	"reflect"
+	"testing"
+)
+
+type E1 struct {
+	F01 int     `schema:"f01"`
+	F02 int     `schema:"-"`
+	F03 string  `schema:"f03"`
+	F04 string  `schema:"f04,omitempty"`
+	F05 bool    `schema:"f05"`
+	F06 bool    `schema:"f06"`
+	F07 *string `schema:"f07"`
+	F08 *int8   `schema:"f08"`
+	F09 float64 `schema:"f09"`
+	F10 func()  `schema:"f10"`
+	F11 inner
+}
+type inner struct {
+	F12 int
+}
+
+func TestFilled(t *testing.T) {
+	f07 := "seven"
+	var f08 int8 = 8
+	s := &E1{
+		F01: 1,
+		F02: 2,
+		F03: "three",
+		F04: "four",
+		F05: true,
+		F06: false,
+		F07: &f07,
+		F08: &f08,
+		F09: 1.618,
+		F10: func() {},
+		F11: inner{12},
+	}
+
+	vals := make(map[string][]string)
+	errs := NewEncoder().Encode(s, vals)
+
+	valExists(t, "f01", "1", vals)
+	valNotExists(t, "f02", vals)
+	valExists(t, "f03", "three", vals)
+	valExists(t, "f05", "true", vals)
+	valExists(t, "f06", "false", vals)
+	valExists(t, "f07", "seven", vals)
+	valExists(t, "f08", "8", vals)
+	valExists(t, "f09", "1.618000", vals)
+	valExists(t, "F12", "12", vals)
+
+	emptyErr := MultiError{}
+	if errs.Error() == emptyErr.Error() {
+		t.Errorf("Expected error got %v", errs)
+	}
+}
+
+type Aa int
+
+type E3 struct {
+	F01 bool    `schema:"f01"`
+	F02 float32 `schema:"f02"`
+	F03 float64 `schema:"f03"`
+	F04 int     `schema:"f04"`
+	F05 int8    `schema:"f05"`
+	F06 int16   `schema:"f06"`
+	F07 int32   `schema:"f07"`
+	F08 int64   `schema:"f08"`
+	F09 string  `schema:"f09"`
+	F10 uint    `schema:"f10"`
+	F11 uint8   `schema:"f11"`
+	F12 uint16  `schema:"f12"`
+	F13 uint32  `schema:"f13"`
+	F14 uint64  `schema:"f14"`
+	F15 Aa      `schema:"f15"`
+}
+
+// Test compatibility with default decoder types.
+func TestCompat(t *testing.T) {
+	src := &E3{
+		F01: true,
+		F02: 4.2,
+		F03: 4.3,
+		F04: -42,
+		F05: -43,
+		F06: -44,
+		F07: -45,
+		F08: -46,
+		F09: "foo",
+		F10: 42,
+		F11: 43,
+		F12: 44,
+		F13: 45,
+		F14: 46,
+		F15: 1,
+	}
+	dst := &E3{}
+
+	vals := make(map[string][]string)
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	encoder.RegisterEncoder(src.F15, func(reflect.Value) string { return "1" })
+	decoder.RegisterConverter(src.F15, func(string) reflect.Value { return reflect.ValueOf(1) })
+
+	err := encoder.Encode(src, vals)
+	if err != nil {
+		t.Errorf("Encoder has non-nil error: %v", err)
+	}
+	err = decoder.Decode(dst, vals)
+	if err != nil {
+		t.Errorf("Decoder has non-nil error: %v", err)
+	}
+
+	if *src != *dst {
+		t.Errorf("Decoder-Encoder compatibility: expected %v, got %v\n", src, dst)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	s := &E1{
+		F01: 1,
+		F02: 2,
+		F03: "three",
+	}
+
+	estr := "schema: encoder not found for <nil>"
+	vals := make(map[string][]string)
+	err := NewEncoder().Encode(s, vals)
+	if err.Error() != estr {
+		t.Errorf("Expected: %s, got %v", estr, err)
+	}
+
+	valExists(t, "f03", "three", vals)
+	valNotExists(t, "f04", vals)
+}
+
+func TestStruct(t *testing.T) {
+	estr := "schema: interface must be a struct"
+	vals := make(map[string][]string)
+	err := NewEncoder().Encode("hello world", vals)
+
+	if err.Error() != estr {
+		t.Errorf("Expected: %s, got %v", estr, err)
+	}
+}
+
+func TestSlices(t *testing.T) {
+	type oneAsWord int
+	ones := []oneAsWord{1, 2}
+	s1 := &struct {
+		ones     []oneAsWord `schema:"ones"`
+		ints     []int       `schema:"ints"`
+		nonempty []int       `schema:"nonempty"`
+		empty    []int       `schema:"empty,omitempty"`
+	}{ones, []int{1, 1}, []int{}, []int{}}
+	vals := make(map[string][]string)
+
+	encoder := NewEncoder()
+	encoder.RegisterEncoder(ones[0], func(v reflect.Value) string { return "one" })
+	err := encoder.Encode(s1, vals)
+	if err != nil {
+		t.Errorf("Encoder has non-nil error: %v", err)
+	}
+
+	valsExist(t, "ones", []string{"one", "one"}, vals)
+	valsExist(t, "ints", []string{"1", "1"}, vals)
+	valsExist(t, "nonempty", []string{}, vals)
+	valNotExists(t, "empty", vals)
+}
+
+func TestCompatSlices(t *testing.T) {
+	type oneAsWord int
+	type s1 struct {
+		Ones []oneAsWord `schema:"ones"`
+		Ints []int       `schema:"ints"`
+	}
+	ones := []oneAsWord{1, 1}
+	src := &s1{ones, []int{1, 1}}
+	vals := make(map[string][]string)
+	dst := &s1{}
+
+	encoder := NewEncoder()
+	encoder.RegisterEncoder(ones[0], func(v reflect.Value) string { return "one" })
+
+	decoder := NewDecoder()
+	decoder.RegisterConverter(ones[0], func(s string) reflect.Value {
+		if s == "one" {
+			return reflect.ValueOf(1)
+		}
+		return reflect.ValueOf(2)
+	})
+
+	err := encoder.Encode(src, vals)
+	if err != nil {
+		t.Errorf("Encoder has non-nil error: %v", err)
+	}
+	err = decoder.Decode(dst, vals)
+	if err != nil {
+		t.Errorf("Dncoder has non-nil error: %v", err)
+	}
+
+	if len(src.Ints) != len(dst.Ints) || len(src.Ones) != len(src.Ones) {
+		t.Fatalf("Expected %v, got %v", src, dst)
+	}
+
+	for i, v := range src.Ones {
+		if dst.Ones[i] != v {
+			t.Fatalf("Expected %v, got %v", v, dst.Ones[i])
+		}
+	}
+
+	for i, v := range src.Ints {
+		if dst.Ints[i] != v {
+			t.Fatalf("Expected %v, got %v", v, dst.Ints[i])
+		}
+	}
+}
+
+func TestRegisterEncoder(t *testing.T) {
+	type oneAsWord int
+	type twoAsWord int
+	type oneSliceAsWord []int
+
+	s1 := &struct {
+		oneAsWord
+		twoAsWord
+		oneSliceAsWord
+	}{1, 2, []int{1, 1}}
+	v1 := make(map[string][]string)
+
+	encoder := NewEncoder()
+	encoder.RegisterEncoder(s1.oneAsWord, func(v reflect.Value) string { return "one" })
+	encoder.RegisterEncoder(s1.twoAsWord, func(v reflect.Value) string { return "two" })
+	encoder.RegisterEncoder(s1.oneSliceAsWord, func(v reflect.Value) string { return "one" })
+
+	err := encoder.Encode(s1, v1)
+	if err != nil {
+		t.Errorf("Encoder has non-nil error: %v", err)
+	}
+
+	valExists(t, "oneAsWord", "one", v1)
+	valExists(t, "twoAsWord", "two", v1)
+	valExists(t, "oneSliceAsWord", "one", v1)
+}
+
+func valExists(t *testing.T, key string, expect string, result map[string][]string) {
+	valsExist(t, key, []string{expect}, result)
+}
+
+func valsExist(t *testing.T, key string, expect []string, result map[string][]string) {
+	vals, ok := result[key]
+	if !ok {
+		t.Fatalf("Key not found. Expected: %s", key)
+	}
+
+	if len(expect) != len(vals) {
+		t.Fatalf("Expected: %v, got: %v", expect, vals)
+	}
+
+	for i, v := range expect {
+		if vals[i] != v {
+			t.Fatalf("Unexpected value. Expected: %v, got %v", v, vals[i])
+		}
+	}
+}
+
+func valNotExists(t *testing.T, key string, result map[string][]string) {
+	if val, ok := result[key]; ok {
+		t.Error("Key not ommited. Expected: empty; got: " + val[0] + ".")
+	}
+}
+
+type E4 struct {
+	ID string `json:"id"`
+}
+
+func TestEncoderSetAliasTag(t *testing.T) {
+	data := map[string][]string{}
+
+	s := E4{
+		ID: "foo",
+	}
+	encoder := NewEncoder()
+	encoder.SetAliasTag("json")
+	encoder.Encode(&s, data)
+	valExists(t, "id", "foo", data)
+}
+
+type E5 struct {
+	F01 int      `schema:"f01,omitempty"`
+	F02 string   `schema:"f02,omitempty"`
+	F03 *string  `schema:"f03,omitempty"`
+	F04 *int8    `schema:"f04,omitempty"`
+	F05 float64  `schema:"f05,omitempty"`
+	F06 E5F06    `schema:"f06,omitempty"`
+	F07 E5F06    `schema:"f07,omitempty"`
+	F08 []string `schema:"f08,omitempty"`
+	F09 []string `schema:"f09,omitempty"`
+}
+
+type E5F06 struct {
+	F0601 string `schema:"f0601,omitempty"`
+}
+
+func TestEncoderWithOmitempty(t *testing.T) {
+	vals := map[string][]string{}
+
+	s := E5{
+		F02: "test",
+		F07: E5F06{
+			F0601: "test",
+		},
+		F09: []string{"test"},
+	}
+
+	encoder := NewEncoder()
+	encoder.Encode(&s, vals)
+
+	valNotExists(t, "f01", vals)
+	valExists(t, "f02", "test", vals)
+	valNotExists(t, "f03", vals)
+	valNotExists(t, "f04", vals)
+	valNotExists(t, "f05", vals)
+	valNotExists(t, "f06", vals)
+	valExists(t, "f0601", "test", vals)
+	valNotExists(t, "f08", vals)
+	valsExist(t, "f09", []string{"test"}, vals)
+}

--- a/yunpian/error.go
+++ b/yunpian/error.go
@@ -1,0 +1,17 @@
+package yunpian
+
+import (
+	"fmt"
+)
+
+// ErrorResponse is the return format when the response fails
+type ErrorResponse struct {
+	HTTPStatusCode int    `json:"http_status_code"`
+	Code           int    `json:"code"`
+	Message        string `json:"msg"`
+	Detail         string `json:"detail"`
+}
+
+func (resp ErrorResponse) Error() string {
+	return fmt.Sprintf("请求失败，StatusCode: %d, Code: %d, Message: %s, Detail: %s", resp.HTTPStatusCode, resp.Code, resp.Message, resp.Detail)
+}

--- a/yunpian/sign.go
+++ b/yunpian/sign.go
@@ -59,7 +59,7 @@ func (sign *Sign) Add(input *SignAddRequest) (*SignAddResponse, error) {
 		return nil, err
 	}
 
-	r := sign.c.newRequest("POST", "/v2/sign/add.json")
+	r := sign.c.newRequest("POST", sign.c.config.signHost, "/v2/sign/add.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sign.c.encodeFormBody(input)
@@ -115,7 +115,7 @@ func (sign *Sign) Get(input *SignGetRequest) (*SignGetResponse, error) {
 		input = &SignGetRequest{}
 	}
 
-	r := sign.c.newRequest("POST", "/v2/sign/get.json")
+	r := sign.c.newRequest("POST", sign.c.config.signHost, "/v2/sign/get.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sign.c.encodeFormBody(input)
@@ -187,7 +187,7 @@ func (sign *Sign) Update(input *SignUpdateRequest) (*SignUpdateResponse, error) 
 		return nil, err
 	}
 
-	r := sign.c.newRequest("POST", "/v2/sign/update.json")
+	r := sign.c.newRequest("POST", sign.c.config.signHost, "/v2/sign/update.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sign.c.encodeFormBody(input)

--- a/yunpian/sign.go
+++ b/yunpian/sign.go
@@ -1,0 +1,211 @@
+package yunpian
+
+import (
+	"errors"
+)
+
+// Sign is used to manipulate the sign API
+type Sign struct {
+	c *Client
+}
+
+// Sign is used to return a handle to the sign APIs
+func (c *Client) Sign() *Sign {
+	return &Sign{c}
+}
+
+// SignAddRequest - 添加签名请求参数
+type SignAddRequest struct {
+	Sign         string `schema:"sign,omitempty"`
+	Notify       bool   `schema:"notify,omitempty"`
+	ApplyVIP     bool   `schema:"apply_vip,omitempty"`
+	OnlyGlobal   bool   `schema:"is_only_global,omitempty"`
+	IndustryType string `schema:"industry_type,omitempty"`
+	LicenseURL   string `schema:"license_url,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *SignAddRequest) Verify() error {
+	if len(req.Sign) == 0 {
+		return errors.New("Miss param: sign")
+	}
+	return nil
+}
+
+// SignAddEntry is
+type SignAddEntry struct {
+	ApplyState   string `json:"apply_state"`
+	Sign         string `json:"sign"`
+	ApplyVIP     bool   `json:"is_apply_vip"`
+	OnlyGlobal   bool   `json:"is_only_global"`
+	IndustryType string `json:"industry_type"`
+}
+
+// SignAddResponse - 添加签名响应
+type SignAddResponse struct {
+	Code    int            `json:"code"`
+	Message string         `json:"msg"`
+	Sign    []SignAddEntry `json:"sign"`
+}
+
+// Add - 添加签名接口
+func (sign *Sign) Add(input *SignAddRequest) (*SignAddResponse, error) {
+	if input == nil {
+		input = &SignAddRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sign.c.newRequest("POST", "/v2/sign/add.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sign.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sign.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SignAddResponse
+	if err = sign.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// SignGetRequest - 获取签名请求参数
+type SignGetRequest struct {
+	Sign     string `schema:"sign,omitempty"`
+	PageNum  int    `schema:"page_num,omitempty"`
+	PageSize int    `schema:"page_size,omitempty"`
+}
+
+// SignGetEntry is
+type SignGetEntry struct {
+	Chan         string `json:"chan"`
+	CheckStatus  string `json:"check_status"`
+	Enabled      bool   `json:"enabled"`
+	Extend       string `json:"extend"`
+	IndustryType string `json:"industry_type"`
+	OnlyGlobal   bool   `json:"only_global"`
+	Remark       string `json:"remark"`
+	Sign         string `json:"sign"`
+	VIP          bool   `json:"vip"`
+}
+
+// SignGetResponse - 获取签名响应
+type SignGetResponse struct {
+	Code  int            `json:"code"`
+	Total int            `json:"total"`
+	Sign  []SignGetEntry `json:"sign"`
+}
+
+// Get - 获取签名接口
+func (sign *Sign) Get(input *SignGetRequest) (*SignGetResponse, error) {
+	if input == nil {
+		input = &SignGetRequest{}
+	}
+
+	r := sign.c.newRequest("POST", "/v2/sign/get.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sign.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sign.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SignGetResponse
+	if err = sign.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// SignUpdateRequest - 修改签名请求参数
+type SignUpdateRequest struct {
+	OldSign      string `schema:"old_sign,omitempty"`
+	Sign         string `schema:"sign,omitempty"`
+	Notify       bool   `schema:"notify,omitempty"`
+	ApplyVIP     bool   `schema:"apply_vip,omitempty"`
+	OnlyGlobal   bool   `schema:"is_only_global,omitempty"`
+	IndustryType string `schema:"industry_type,omitempty"`
+	LicenseURL   string `schema:"license_url,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *SignUpdateRequest) Verify() error {
+	if len(req.OldSign) == 0 {
+		return errors.New("Miss param: old_sign")
+	}
+	if len(req.Sign) == 0 {
+		return errors.New("Miss param: sign")
+	}
+	return nil
+}
+
+// SignUpdateEntry is
+type SignUpdateEntry struct {
+	ApplyState   string `json:"apply_state"`
+	Sign         string `json:"sign"`
+	ApplyVIP     bool   `json:"is_apply_vip"`
+	OnlyGlobal   bool   `json:"is_only_global"`
+	IndustryType string `json:"industry_type"`
+}
+
+// SignUpdateResponse - 修改签名响应
+type SignUpdateResponse struct {
+	Code    int             `json:"code"`
+	Message string          `json:"msg"`
+	Sign    SignUpdateEntry `json:"sign"`
+}
+
+// Update - 修改签名接口
+func (sign *Sign) Update(input *SignUpdateRequest) (*SignUpdateResponse, error) {
+	if input == nil {
+		input = &SignUpdateRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sign.c.newRequest("POST", "/v2/sign/update.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sign.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sign.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SignUpdateResponse
+	if err = sign.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/sign_test.go
+++ b/yunpian/sign_test.go
@@ -1,0 +1,19 @@
+package yunpian
+
+import (
+	"testing"
+)
+
+func TestSignGet(t *testing.T) {
+	sign := TestClient.Sign()
+	input := &SignGetRequest{
+		PageNum:  1,
+		PageSize: 10,
+	}
+
+	resp, err := sign.Get(input)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(resp)
+}

--- a/yunpian/sms.go
+++ b/yunpian/sms.go
@@ -1,0 +1,149 @@
+package yunpian
+
+import (
+	"errors"
+)
+
+// SMS is used to manipulate the sms API
+type SMS struct {
+	c *Client
+}
+
+// SMS is used to return a handle to the SMS APIs
+func (c *Client) SMS() *SMS {
+	return &SMS{c}
+}
+
+// SingleSendRequest - 单条短信发送参数
+type SingleSendRequest struct {
+	Mobile      string `schema:"mobile"`
+	Text        string `schema:"text"`
+	Extend      string `schema:"extend"`
+	UID         string `schema:"uid"`
+	CallbackURL string `schema:"callback_url"`
+	Register    bool   `schema:"register"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *SingleSendRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if len(req.Text) == 0 {
+		return errors.New("Miss param: text")
+	}
+
+	return nil
+}
+
+// SingleSendResponse - 单条短信发送响应
+type SingleSendResponse struct {
+	Code    int     `json:"code"`
+	Message string  `json:"msg"`
+	Count   int     `json:"count"`
+	Fee     float64 `json:"fee"`
+	Unit    string  `json:"unit"`
+	Mobile  string  `json:"mobile"`
+	SID     int64   `json:"sid"`
+}
+
+// IsSuccess used to determine whether to send successfully
+func (resp *SingleSendResponse) IsSuccess() bool {
+	return resp.Code == 0
+}
+
+// SingleSend - 单条短信发送接口
+func (sms *SMS) SingleSend(input *SingleSendRequest) (*SingleSendResponse, error) {
+	if input == nil {
+		input = &SingleSendRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/single_send.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SingleSendResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// BatchSendRequest - 批量发送请求参数
+type BatchSendRequest struct {
+	Mobile      string `schema:"mobile"`
+	Text        string `schema:"text"`
+	Extend      string `schema:"extend"`
+	CallbackURL string `schema:"callback_url"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *BatchSendRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if len(req.Text) == 0 {
+		return errors.New("Miss param: text")
+	}
+
+	return nil
+}
+
+// BatchSendResponse - 批量发送响应结构
+type BatchSendResponse struct {
+	TotalCount int                  `json:"total_count"`
+	TotalFee   string               `json:"total_fee"`
+	Unit       string               `json:"unit"`
+	Data       []SingleSendResponse `json:"data"`
+}
+
+// BatchSend - 批量发送接口
+func (sms *SMS) BatchSend(input *BatchSendRequest) (*BatchSendResponse, error) {
+	if input == nil {
+		input = &BatchSendRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/batch_send.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result BatchSendResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/sms.go
+++ b/yunpian/sms.go
@@ -63,7 +63,7 @@ func (sms *SMS) SingleSend(input *SingleSendRequest) (*SingleSendResponse, error
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/single_send.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/single_send.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -125,7 +125,7 @@ func (sms *SMS) BatchSend(input *BatchSendRequest) (*BatchSendResponse, error) {
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/batch_send.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/batch_send.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -187,7 +187,7 @@ func (sms *SMS) MultiSend(input *MultiSendRequest) (*MultiSendResponse, error) {
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/multi_send.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/multi_send.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -245,7 +245,7 @@ func (sms *SMS) TPLSingleSend(input *TPLSingleSendRequest) (*SingleSendResponse,
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/tpl_single_send.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/tpl_single_send.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -303,7 +303,7 @@ func (sms *SMS) TPLBatchSend(input *TPLBatchSendRequest) (*BatchSendResponse, er
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/tpl_batch_send.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/tpl_batch_send.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -347,7 +347,7 @@ func (sms *SMS) PullStatus(input *PullStatusRequest) ([]*PullStatusResponse, err
 		input = &PullStatusRequest{}
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/pull_status.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/pull_status.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -392,7 +392,7 @@ func (sms *SMS) PullReply(input *PullReplyRequest) ([]*PullReplyResponse, error)
 		input = &PullReplyRequest{}
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/pull_reply.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/pull_reply.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -461,7 +461,7 @@ func (sms *SMS) GetRecord(input *GetRecordRequest) ([]*GetRecordResponse, error)
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/get_record.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/get_record.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)
@@ -517,7 +517,7 @@ func (sms *SMS) GetTotalFee(input *GetTotalFeeRequest) (*GetTotalFeeResponse, er
 		return nil, err
 	}
 
-	r := sms.c.newRequest("POST", "/v2/sms/get_total_fee.json")
+	r := sms.c.newRequest("POST", sms.c.config.smsHost, "/v2/sms/get_total_fee.json")
 	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	reader, err := sms.c.encodeFormBody(input)

--- a/yunpian/sms.go
+++ b/yunpian/sms.go
@@ -16,12 +16,12 @@ func (c *Client) SMS() *SMS {
 
 // SingleSendRequest - 单条短信发送参数
 type SingleSendRequest struct {
-	Mobile      string `schema:"mobile"`
-	Text        string `schema:"text"`
-	Extend      string `schema:"extend"`
-	UID         string `schema:"uid"`
-	CallbackURL string `schema:"callback_url"`
-	Register    bool   `schema:"register"`
+	Mobile      string `schema:"mobile,omitempty"`
+	Text        string `schema:"text,omitempty"`
+	Extend      string `schema:"extend,omitempty"`
+	UID         string `schema:"uid,omitempty"`
+	CallbackURL string `schema:"callback_url,omitempty"`
+	Register    bool   `schema:"register,omitempty"`
 }
 
 // Verify used to check the correctness of the request parameters
@@ -88,10 +88,10 @@ func (sms *SMS) SingleSend(input *SingleSendRequest) (*SingleSendResponse, error
 
 // BatchSendRequest - 批量发送请求参数
 type BatchSendRequest struct {
-	Mobile      string `schema:"mobile"`
-	Text        string `schema:"text"`
-	Extend      string `schema:"extend"`
-	CallbackURL string `schema:"callback_url"`
+	Mobile      string `schema:"mobile,omitempty"`
+	Text        string `schema:"text,omitempty"`
+	Extend      string `schema:"extend,omitempty"`
+	CallbackURL string `schema:"callback_url,omitempty"`
 }
 
 // Verify used to check the correctness of the request parameters
@@ -150,10 +150,10 @@ func (sms *SMS) BatchSend(input *BatchSendRequest) (*BatchSendResponse, error) {
 
 // MultiSendRequest - 批量个性化发送请求参数
 type MultiSendRequest struct {
-	Mobile      string `schema:"mobile"`
-	Text        string `schema:"text"`
-	Extend      string `schema:"extend"`
-	CallbackURL string `schema:"callback_url"`
+	Mobile      string `schema:"mobile,omitempty"`
+	Text        string `schema:"text,omitempty"`
+	Extend      string `schema:"extend,omitempty"`
+	CallbackURL string `schema:"callback_url,omitempty"`
 }
 
 // Verify used to check the correctness of the request parameters
@@ -212,11 +212,11 @@ func (sms *SMS) MultiSend(input *MultiSendRequest) (*MultiSendResponse, error) {
 
 // TPLSingleSendRequest - 指定模板单发请求参数
 type TPLSingleSendRequest struct {
-	Mobile   string `schema:"mobile"`
-	TPLID    int64  `schema:"tpl_id"`
-	TPLValue string `schema:"tpl_value"`
-	Extend   string `schema:"extend"`
-	UID      string `schema:"uid"`
+	Mobile   string `schema:"mobile,omitempty"`
+	TPLID    int64  `schema:"tpl_id,omitempty"`
+	TPLValue string `schema:"tpl_value,omitempty"`
+	Extend   string `schema:"extend,omitempty"`
+	UID      string `schema:"uid,omitempty"`
 }
 
 // Verify used to check the correctness of the request parameters
@@ -270,11 +270,11 @@ func (sms *SMS) TPLSingleSend(input *TPLSingleSendRequest) (*SingleSendResponse,
 
 // TPLBatchSendRequest - 指定模板群发请求参数
 type TPLBatchSendRequest struct {
-	Mobile   string `schema:"mobile"`
-	TPLID    int64  `schema:"tpl_id"`
-	TPLValue string `schema:"tpl_value"`
-	Extend   string `schema:"extend"`
-	UID      string `schema:"uid"`
+	Mobile   string `schema:"mobile,omitempty"`
+	TPLID    int64  `schema:"tpl_id,omitempty"`
+	TPLValue string `schema:"tpl_value,omitempty"`
+	Extend   string `schema:"extend,omitempty"`
+	UID      string `schema:"uid,omitempty"`
 }
 
 // Verify used to check the correctness of the request parameters
@@ -328,7 +328,7 @@ func (sms *SMS) TPLBatchSend(input *TPLBatchSendRequest) (*BatchSendResponse, er
 
 // PullStatusRequest - 获取状态报告请求参数
 type PullStatusRequest struct {
-	PageSize int `schema:"page_size"`
+	PageSize int `schema:"page_size,omitempty"`
 }
 
 // PullStatusResponse - 获取状态报告响应
@@ -372,7 +372,7 @@ func (sms *SMS) PullStatus(input *PullStatusRequest) ([]*PullStatusResponse, err
 
 // PullReplyRequest - 获取回复短信请求参数
 type PullReplyRequest struct {
-	PageSize int `schema:"page_size"`
+	PageSize int `schema:"page_size,omitempty"`
 }
 
 // PullReplyResponse - 获取回复短信响应

--- a/yunpian/sms.go
+++ b/yunpian/sms.go
@@ -147,3 +147,270 @@ func (sms *SMS) BatchSend(input *BatchSendRequest) (*BatchSendResponse, error) {
 
 	return &result, nil
 }
+
+// MultiSendRequest - 批量个性化发送请求参数
+type MultiSendRequest struct {
+	Mobile      string `schema:"mobile"`
+	Text        string `schema:"text"`
+	Extend      string `schema:"extend"`
+	CallbackURL string `schema:"callback_url"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *MultiSendRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if len(req.Text) == 0 {
+		return errors.New("Miss param: text")
+	}
+
+	return nil
+}
+
+// MultiSendResponse - 批量个性化发送响应
+type MultiSendResponse struct {
+	TotalCount int                  `json:"total_count"`
+	TotalFee   string               `json:"total_fee"`
+	Unit       string               `json:"unit"`
+	Data       []SingleSendResponse `json:"data"`
+}
+
+// MultiSend - 批量个性化发送接口
+func (sms *SMS) MultiSend(input *MultiSendRequest) (*MultiSendResponse, error) {
+	if input == nil {
+		input = &MultiSendRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/multi_send.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result MultiSendResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// TPLSingleSendRequest - 指定模板单发请求参数
+type TPLSingleSendRequest struct {
+	Mobile   string `schema:"mobile"`
+	TPLID    int64  `schema:"tpl_id"`
+	TPLValue string `schema:"tpl_value"`
+	Extend   string `schema:"extend"`
+	UID      string `schema:"uid"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLSingleSendRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if req.TPLID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	if len(req.TPLValue) == 0 {
+		return errors.New("Miss param: tpl_value")
+	}
+
+	return nil
+}
+
+// TPLSingleSend - 指定模板单发接口
+func (sms *SMS) TPLSingleSend(input *TPLSingleSendRequest) (*SingleSendResponse, error) {
+	if input == nil {
+		input = &TPLSingleSendRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/tpl_single_send.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SingleSendResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// TPLBatchSendRequest - 指定模板群发请求参数
+type TPLBatchSendRequest struct {
+	Mobile   string `schema:"mobile"`
+	TPLID    int64  `schema:"tpl_id"`
+	TPLValue string `schema:"tpl_value"`
+	Extend   string `schema:"extend"`
+	UID      string `schema:"uid"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLBatchSendRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if req.TPLID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	if len(req.TPLValue) == 0 {
+		return errors.New("Miss param: tpl_value")
+	}
+
+	return nil
+}
+
+// TPLBatchSend - 指定模板群发
+func (sms *SMS) TPLBatchSend(input *TPLBatchSendRequest) (*BatchSendResponse, error) {
+	if input == nil {
+		input = &TPLBatchSendRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/tpl_batch_send.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result BatchSendResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// PullStatusRequest - 获取状态报告请求参数
+type PullStatusRequest struct {
+	PageSize int `schema:"page_size"`
+}
+
+// PullStatusResponse - 获取状态报告响应
+type PullStatusResponse struct {
+	SID             int64  `json:"sid"`
+	UID             string `json:"uid"`
+	UserReceiveTime string `json:"user_receive_time"`
+	ErrorMessage    string `json:"error_msg"`
+	Mobile          string `json:"mobile"`
+	ReportStatus    string `json:"report_status"`
+}
+
+// PullStatus - 获取状态报告接口
+func (sms *SMS) PullStatus(input *PullStatusRequest) ([]*PullStatusResponse, error) {
+	if input == nil {
+		input = &PullStatusRequest{}
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/pull_status.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result []*PullStatusResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// PullReplyRequest - 获取回复短信请求参数
+type PullReplyRequest struct {
+	PageSize int `schema:"page_size"`
+}
+
+// PullReplyResponse - 获取回复短信响应
+type PullReplyResponse struct {
+	ID         string `json:"id"`
+	Mobile     string `json:"mobile"`
+	Text       string `json:"text"`
+	ReplyTime  string `json:"reply_time"`
+	Extend     string `json:"extend"`
+	BaseExtend string `json:"base_extend"`
+	Sign       string `json:"_sign"`
+}
+
+// PullReply - 获取回复短信接口
+func (sms *SMS) PullReply(input *PullReplyRequest) ([]*PullReplyResponse, error) {
+	if input == nil {
+		input = &PullReplyRequest{}
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/pull_reply.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result []*PullReplyResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/yunpian/sms.go
+++ b/yunpian/sms.go
@@ -414,3 +414,128 @@ func (sms *SMS) PullReply(input *PullReplyRequest) ([]*PullReplyResponse, error)
 
 	return result, nil
 }
+
+// GetRecordRequest - 查短信发送记录请求参数
+type GetRecordRequest struct {
+	Mobile    string `schema:"mobile,omitempty"`
+	StartTime string `schema:"start_time,omitempty"`
+	EndTime   string `schema:"end_time,omitempty"`
+	PageNum   int    `schema:"page_num,omitempty"`
+	PageSize  int    `schema:"page_size,omitempty"`
+	Type      string `schema:"type,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *GetRecordRequest) Verify() error {
+	if len(req.StartTime) == 0 {
+		return errors.New("Miss param: start_time")
+	}
+	if len(req.EndTime) == 0 {
+		return errors.New("Miss param: end_time")
+	}
+	return nil
+}
+
+// GetRecordResponse - 查短信发送记录响应
+type GetRecordResponse struct {
+	SID             string  `json:"sid"`
+	Mobile          string  `json:"mobile"`
+	SendTime        string  `json:"send_time"`
+	Text            string  `json:"text"`
+	SendStatus      string  `json:"send_status"`
+	ReportStatus    string  `json:"report_status"`
+	Fee             float64 `json:"fee"`
+	UserReceiveTime string  `json:"user_receive_time"`
+	ErrorMessage    string  `json:"error_msg"`
+	UID             string  `json:"uid"`
+}
+
+// GetRecord - 查短信发送记录接口
+func (sms *SMS) GetRecord(input *GetRecordRequest) ([]*GetRecordResponse, error) {
+	if input == nil {
+		input = &GetRecordRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/get_record.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result []*GetRecordResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetTotalFeeRequest - 日账单导出请求参数
+type GetTotalFeeRequest struct {
+	Date string `schema:"date"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *GetTotalFeeRequest) Verify() error {
+	if len(req.Date) == 0 {
+		return errors.New("Miss param: date")
+	}
+	return nil
+}
+
+// GetTotalFeeResponse - 日账单导出响应
+type GetTotalFeeResponse struct {
+	Count        int    `json:"totalCount"`
+	Fee          string `json:"totalFee"`
+	SuccessCount int    `json:"totalSuccessCount"`
+	FailedCount  int    `json:"totalFailedCount"`
+	UnknownCount int    `json:"totalUnknownCount"`
+}
+
+// GetTotalFee - 日账单导出接口
+func (sms *SMS) GetTotalFee(input *GetTotalFeeRequest) (*GetTotalFeeResponse, error) {
+	if input == nil {
+		input = &GetTotalFeeRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := sms.c.newRequest("POST", "/v2/sms/get_total_fee.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := sms.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := sms.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result GetTotalFeeResponse
+	if err = sms.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/sms_test.go
+++ b/yunpian/sms_test.go
@@ -1,0 +1,31 @@
+package yunpian
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSingleSend(t *testing.T) {
+	sms := TestClient.SMS()
+	input := &SingleSendRequest{
+		Mobile: "13320942172",
+		Text:   "您的验证码是1234。如非本人操作，请忽略本短信",
+	}
+
+	resp, err := sms.SingleSend(input)
+	if err != nil {
+		t.Error(err)
+	}
+	if !resp.IsSuccess() {
+		t.Errorf("测试短信发送失败：%s", resp.Message)
+	}
+}
+
+func TestDecodeSingleSendResponseBody(t *testing.T) {
+	body := `{"code":0,"msg":"发送成功","count":1,"fee":0.045,"unit":"RMB","mobile":"13320942172","sid":19473255234}`
+	var resp SingleSendResponse
+	err := json.Unmarshal([]byte(body), &resp)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/yunpian/sms_test.go
+++ b/yunpian/sms_test.go
@@ -29,3 +29,16 @@ func TestDecodeSingleSendResponseBody(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetTotalFee(t *testing.T) {
+	sms := TestClient.SMS()
+	input := &GetTotalFeeRequest{
+		Date: "2017-12-01",
+	}
+
+	resp, err := sms.GetTotalFee(input)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(resp.Count)
+}

--- a/yunpian/tpl.go
+++ b/yunpian/tpl.go
@@ -1,0 +1,300 @@
+package yunpian
+
+import "errors"
+
+// TPL is used to manipulate the tpl API
+type TPL struct {
+	c *Client
+}
+
+// TPL is used to return a handle to the TPL APIs
+func (c *Client) TPL() *TPL {
+	return &TPL{c}
+}
+
+// TPLAddRequest - 添加模版请求参数
+type TPLAddRequest struct {
+	Content    string `schema:"tpl_content,omitempty"`
+	NotifyType string `schema:"notify_type,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLAddRequest) Verify() error {
+	if len(req.Content) == 0 {
+		return errors.New("Miss param: tpl_content")
+	}
+	return nil
+}
+
+// TPLResponse - 添加模版响应
+type TPLResponse struct {
+	ID      int64  `json:"tpl_id"`
+	Content string `json:"tpl_content"`
+	Status  string `json:"check_status"`
+	Reason  string `json:"reason"`
+}
+
+// Add - 添加模版接口
+func (tpl *TPL) Add(input *TPLAddRequest) (*TPLResponse, error) {
+	if input == nil {
+		input = &TPLAddRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", "/v2/tpl/add.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// TPLGetRequest - 获取模板请求参数
+type TPLGetRequest struct {
+	ID int64 `schema:"tpl_id,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLGetRequest) Verify() error {
+	if req.ID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	return nil
+}
+
+// Get - 获取模板接口
+func (tpl *TPL) Get(input *TPLGetRequest) (*TPLResponse, error) {
+	if input == nil {
+		input = &TPLGetRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", "/v2/tpl/get.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetDefault - 取默认模板接口
+func (tpl *TPL) GetDefault(input *TPLGetRequest) (*TPLResponse, error) {
+	if input == nil {
+		input = &TPLGetRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", "/v2/tpl/get_default.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// List - 获取模版列表接口
+func (tpl *TPL) List() ([]*TPLResponse, error) {
+	input := &TPLGetRequest{}
+	r := tpl.c.newRequest("POST", "/v2/tpl/get.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result []*TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// ListDefault - 获取默认模版列表接口
+func (tpl *TPL) ListDefault() ([]*TPLResponse, error) {
+	input := &TPLGetRequest{}
+	r := tpl.c.newRequest("POST", "/v2/tpl/get_default.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result []*TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// TPLUpdateRequest - 修改模版请求参数
+type TPLUpdateRequest struct {
+	ID      int64  `schema:"tpl_id,omitempty"`
+	Content string `schema:"tpl_content,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLUpdateRequest) Verify() error {
+	if req.ID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	if len(req.Content) == 0 {
+		return errors.New("Miss param: tpl_content")
+	}
+	return nil
+}
+
+// Update - 修改模版接口
+func (tpl *TPL) Update(input *TPLUpdateRequest) (*TPLResponse, error) {
+	if input == nil {
+		input = &TPLUpdateRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", "/v2/tpl/update.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// TPLDelRequest - 删除模板请求参数
+type TPLDelRequest struct {
+	ID int64 `schema:"tpl_id"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLDelRequest) Verify() error {
+	if req.ID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	return nil
+}
+
+// Del - 删除模板接口
+func (tpl *TPL) Del(input *TPLDelRequest) (*TPLResponse, error) {
+	if input == nil {
+		input = &TPLDelRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", "/v2/tpl/del.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/tpl.go
+++ b/yunpian/tpl.go
@@ -335,3 +335,118 @@ func (tpl *TPL) Del(input *TPLDelRequest) (*TPLResponse, error) {
 
 	return &result, nil
 }
+
+// TPLAddVoiceNotifyRequest - 添加语音通知模版请求参数
+type TPLAddVoiceNotifyRequest struct {
+	Content    string `schema:"tpl_content,omitempty"`
+	NotifyType int    `scheam:"notify_type,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLAddVoiceNotifyRequest) Verify() error {
+	if len(req.Content) == 0 {
+		return errors.New("Miss param: tpl_content")
+	}
+	return nil
+}
+
+// TPLAddVoiceNotifyResponse - 添加语音通知模版响应
+type TPLAddVoiceNotifyResponse struct {
+	ID          string `json:"tpl_id"`
+	Content     string `json:"tpl_content"`
+	CheckStatus string `json:"check_status"`
+	Reason      string `json:"reason"`
+}
+
+// AddVoiceNotify - 添加语音通知模版接口
+func (tpl *TPL) AddVoiceNotify(input *TPLAddVoiceNotifyRequest) (*TPLAddVoiceNotifyResponse, error) {
+	if input == nil {
+		input = &TPLAddVoiceNotifyRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", tpl.c.config.tplHost, "/v2/tpl/add_voice_notify.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLAddVoiceNotifyResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// TPLUpdateVoiceNotifyRequest - 修改语音通知模版请求参数
+type TPLUpdateVoiceNotifyRequest struct {
+	ID      int64  `schema:"tpl_id,omitempty"`
+	Content string `schema:"tpl_content,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *TPLUpdateVoiceNotifyRequest) Verify() error {
+	if req.ID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	if len(req.Content) == 0 {
+		return errors.New("Miss param: tpl_content")
+	}
+	return nil
+}
+
+// TPLUpdateVoiceNotifyResponse - 修改语音通知模版响应
+type TPLUpdateVoiceNotifyResponse struct {
+	ID          int64  `json:"tpl_id"`
+	Content     string `json:"tpl_content"`
+	CheckStatus string `json:"check_status"`
+	Reason      string `json:"reason"`
+}
+
+// UpdateVocieNotify - 修改语音通知模版接口
+func (tpl *TPL) UpdateVocieNotify(input *TPLUpdateVoiceNotifyRequest) (*TPLUpdateVoiceNotifyResponse, error) {
+	if input == nil {
+		input = &TPLUpdateVoiceNotifyRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := tpl.c.newRequest("POST", tpl.c.config.tplHost, "/v2/tpl/update_voice_notify.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := tpl.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := tpl.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result TPLUpdateVoiceNotifyResponse
+	if err = tpl.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/tpl_test.go
+++ b/yunpian/tpl_test.go
@@ -1,0 +1,36 @@
+package yunpian
+
+import (
+	"testing"
+)
+
+func TestTPLGet(t *testing.T) {
+	tpl := TestClient.TPL()
+	input := &TPLGetRequest{ID: 2077620}
+	resp, err := tpl.Get(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(resp.Content)
+}
+
+func TestTPLList(t *testing.T) {
+	tpl := TestClient.TPL()
+	resp, err := tpl.List()
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(len(resp))
+}
+
+func TestTPLListDefault(t *testing.T) {
+	tpl := TestClient.TPL()
+	resp, err := tpl.ListDefault()
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(len(resp))
+}

--- a/yunpian/user.go
+++ b/yunpian/user.go
@@ -1,0 +1,86 @@
+package yunpian
+
+// User is used to manipulate the user API
+type User struct {
+	c *Client
+}
+
+// User is used to return a handle to the user APIs
+func (c *Client) User() *User {
+	return &User{c}
+}
+
+// UserResponse - 账户信息响应
+type UserResponse struct {
+	Nick             string  `json:"nick"`
+	Created          string  `json:"gmt_created"`
+	Mobile           string  `json:"mobile"`
+	Email            string  `json:"email"`
+	IPWhitelist      string  `json:"ip_whitelist"`
+	APIVersion       string  `json:"api_version"`
+	Balance          float64 `json:"balance"`
+	AlarmBalance     int64   `json:"alarm_balance"`
+	EmergencyContact string  `json:"emergency_contact"`
+	EmergencyMobile  string  `json:"emergency_mobile"`
+}
+
+// Get - 查询账户信息接口
+func (u *User) Get() (*UserResponse, error) {
+	r := u.c.newRequest("POST", u.c.config.userHost, "/v2/user/get.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := u.c.encodeFormBody(struct{}{})
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := u.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result UserResponse
+	if err = u.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// UserSetRequest - 修改账号信息请求参数
+type UserSetRequest struct {
+	EmergencyContact string `schema:"emergency_contact,omitempty"`
+	EmergencyMobile  string `schema:"emergency_mobile,omitempty"`
+	AlarmBalance     int64  `schema:"alarm_balance,omitempty"`
+}
+
+// Set - 修改账号信息接口
+func (u *User) Set(input *UserSetRequest) (*UserResponse, error) {
+	if input == nil {
+		input = &UserSetRequest{}
+	}
+
+	r := u.c.newRequest("POST", u.c.config.userHost, "/v2/user/set.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := u.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := u.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result UserResponse
+	if err = u.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/user_test.go
+++ b/yunpian/user_test.go
@@ -1,0 +1,29 @@
+package yunpian
+
+import (
+	"testing"
+)
+
+func TestUserGet(t *testing.T) {
+	user := TestClient.User()
+	resp, err := user.Get()
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(resp)
+}
+
+func TestUserSet(t *testing.T) {
+	user := TestClient.User()
+	input := &UserSetRequest{
+		AlarmBalance: 15,
+	}
+	resp, err := user.Set(input)
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.AlarmBalance != 15 {
+		t.Error(resp)
+	}
+}

--- a/yunpian/voice.go
+++ b/yunpian/voice.go
@@ -1,0 +1,185 @@
+package yunpian
+
+import (
+	"errors"
+)
+
+// Voice is used to manipulate the voice API
+type Voice struct {
+	c *Client
+}
+
+// Voice is used to return a handle to the voice APIs
+func (c *Client) Voice() *Voice {
+	return &Voice{c}
+}
+
+// VoiceSendRequest - 语音验证码请求参数
+type VoiceSendRequest struct {
+	Mobile      string `schema:"mobile,omitempty"`
+	Code        string `schema:"code,omitempty"`
+	CallbackURL string `schema:"callback_url,omitempty"`
+	DisplayNum  string `schema:"display_num,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *VoiceSendRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if len(req.Code) == 0 {
+		return errors.New("Miss param: code")
+	}
+
+	return nil
+}
+
+// VoiceSendResponse - 语音验证码响应
+type VoiceSendResponse struct {
+	Count int    `json:"count"`
+	Fee   int    `json:"fee"`
+	SID   string `json:"sid"`
+}
+
+// Send - 语音验证码发送接口
+func (v *Voice) Send(input *VoiceSendRequest) (*VoiceSendResponse, error) {
+	if input == nil {
+		input = &VoiceSendRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := v.c.newRequest("POST", v.c.config.voiceHost, "/v2/voice/send.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := v.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := v.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result VoiceSendResponse
+	if err = v.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// VoicePullStatusRequest - 语音状态报告获取请求参数
+type VoicePullStatusRequest struct {
+	PageSize int `schema:"page_size,omitempty"`
+	Type     int `scheam:"type,omitempty"`
+}
+
+// VoicePullStatusResponse - 语音状态报告获取响应
+type VoicePullStatusResponse struct {
+	SID             string `json:"sid"`
+	UID             string `json:"uid"`
+	UserReceiveTime string `json:"user_receive_time"`
+	Duration        int    `json:"duration"`
+	ErrorMessage    string `json:"error_msg"`
+	Mobile          string `json:"mobile"`
+	ReportStatus    string `json:"report_status"`
+}
+
+// PullStatus - 语音状态报告获取接口
+func (v *Voice) PullStatus(input *VoicePullStatusRequest) ([]*VoicePullStatusResponse, error) {
+	if input == nil {
+		input = &VoicePullStatusRequest{}
+	}
+
+	r := v.c.newRequest("POST", v.c.config.voiceHost, "/v2/voice/pull_status.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := v.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := v.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result []*VoicePullStatusResponse
+	if err = v.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// VoiceTPLNotifyRequest - 发送语音通知请求参数
+type VoiceTPLNotifyRequest struct {
+	Mobile      string `schema:"mobile,omitempty"`
+	TPLID       int64  `schema:"tpl_id,omitempty"`
+	TPLValue    string `schema:"tpl_value,omitempty"`
+	CallbackURL string `schema:"callback_url,omitempty"`
+}
+
+// Verify used to check the correctness of the request parameters
+func (req *VoiceTPLNotifyRequest) Verify() error {
+	if len(req.Mobile) == 0 {
+		return errors.New("Miss param: mobile")
+	}
+	if req.TPLID == 0 {
+		return errors.New("Miss param: tpl_id")
+	}
+	if len(req.TPLValue) == 0 {
+		return errors.New("Miss param: tpl_value")
+	}
+	return nil
+}
+
+// VoiceTPLNotifyResponse - 发送语音通知响应
+type VoiceTPLNotifyResponse struct {
+	Count int    `json:"count"`
+	Fee   int    `json:"fee"`
+	SID   string `json:"sid"`
+}
+
+// TPLNotify - 发送语音通知接口
+func (v *Voice) TPLNotify(input *VoiceTPLNotifyRequest) (*VoiceTPLNotifyResponse, error) {
+	if input == nil {
+		input = &VoiceTPLNotifyRequest{}
+	}
+
+	err := input.Verify()
+	if err != nil {
+		return nil, err
+	}
+
+	r := v.c.newRequest("POST", v.c.config.voiceHost, "/v2/voice/tpl_notify.json")
+	r.header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+
+	reader, err := v.c.encodeFormBody(input)
+	if err != nil {
+		return nil, err
+	}
+	r.body = reader
+
+	resp, err := v.c.doRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result VoiceTPLNotifyResponse
+	if err = v.c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/yunpian/voice_test.go
+++ b/yunpian/voice_test.go
@@ -1,0 +1,17 @@
+package yunpian
+
+import (
+	"testing"
+)
+
+func TestVoicePullStatus(t *testing.T) {
+	voice := TestClient.Voice()
+	input := &VoicePullStatusRequest{
+		PageSize: 10,
+	}
+	resp, err := voice.PullStatus(input)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(resp)
+}


### PR DESCRIPTION
新的SDK代码在`yunpian`文件夹下，请评审。
新接口的调用方式，以发送单个SMS短信为例：

```Go
cfg := DefaultConfig().WithAPIKey("" /*you api key*/)
sms := NewClient(cfg).SMS()

input := &SingleSendRequest{
	Mobile: "13800138000",
	Text:   "您的验证码是1234。如非本人操作，请忽略本短信",
}

resp, err := sms.SingleSend(input)
if err != nil {
	// handle error
	return
}

if !resp.IsSuccess() {
	// 发送失败
	return
}

// 正常业务流程
```

目前只实现了V2接口，如果需要实现V1接口，请自行实现。
由于我没有测试API KEY，因此测试用例不是很齐全，如果需要请自行补齐。